### PR TITLE
feat(cloud-auth)☁️: add cloud-agnostic authentication parameters to C…

### DIFF
--- a/.cursor/commands/branch-and-commit.md
+++ b/.cursor/commands/branch-and-commit.md
@@ -1,0 +1,1 @@
+Given everything we just did, or given what you see when you run git diff, give me a new git branch and git add and commit all the changes. You do not need to give me a commit message, I have a git commit message writer. If there are any commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -735,6 +735,7 @@ When writing tests for the project:
 - **Follow existing test patterns** - Use the same structure and naming conventions as existing tests in the test suite
 - **Use pytest function style only** - Write tests as functions, not classes. Use `def test_function_name():` pattern
 - **No test classes** - Avoid `class TestSomething:` patterns. Use function-based tests with descriptive names
+- **PyTest Style Only** - All tests must be written with PyTest style test functions, NOT UnitTest test style classes
 
 **Pytest-Style Test Functions** (PREFERRED):
 

--- a/docs/cloud-storage-auth.md
+++ b/docs/cloud-storage-auth.md
@@ -2,7 +2,94 @@
 
 When using `kirin` with cloud storage backends (S3, GCS, Azure, etc.), you need
 to provide authentication credentials. This guide shows you how to authenticate
-with different cloud providers.
+with different cloud providers using the new cloud-agnostic authentication parameters.
+
+## New Cloud-Agnostic Authentication (Recommended)
+
+Kirin now supports cloud-agnostic authentication parameters that work across all cloud providers:
+
+### AWS/S3 Authentication
+
+```python
+from kirin import Catalog, Dataset
+
+# Using AWS profile
+catalog = Catalog(
+    root_dir="s3://my-bucket/data",
+    aws_profile="my-profile"
+)
+
+# Using Dataset with AWS profile
+dataset = Dataset(
+    root_dir="s3://my-bucket/data",
+    name="my-dataset",
+    aws_profile="my-profile"
+)
+```
+
+### GCP/GCS Authentication
+
+```python
+from kirin import Catalog, Dataset
+
+# Using service account key file
+catalog = Catalog(
+    root_dir="gs://my-bucket/data",
+    gcs_token="/path/to/service-account.json",
+    gcs_project="my-project"
+)
+
+# Using Dataset with GCS credentials
+dataset = Dataset(
+    root_dir="gs://my-bucket/data",
+    name="my-dataset",
+    gcs_token="/path/to/service-account.json",
+    gcs_project="my-project"
+)
+```
+
+### Azure Blob Storage Authentication
+
+```python
+from kirin import Catalog, Dataset
+
+# Using connection string
+catalog = Catalog(
+    root_dir="az://my-container/data",
+    azure_connection_string="DefaultEndpointsProtocol=https;..."
+)
+
+# Using account name and key
+dataset = Dataset(
+    root_dir="az://my-container/data",
+    name="my-dataset",
+    azure_account_name="my-account",
+    azure_account_key="my-key"
+)
+```
+
+### Web UI Integration
+
+The web UI also supports cloud authentication through the `CatalogConfig.to_catalog()` method:
+
+```python
+from kirin.web.config import CatalogConfig
+
+# Create catalog config with cloud auth
+config = CatalogConfig(
+    id="my-catalog",
+    name="My Catalog",
+    root_dir="s3://my-bucket/data",
+    aws_profile="my-profile"
+)
+
+# Convert to runtime catalog
+catalog = config.to_catalog()
+```
+
+## Legacy Authentication Methods
+
+The following sections show the legacy authentication methods that still work but are less convenient than the new cloud-agnostic approach.
 
 ## Google Cloud Storage (GCS)
 
@@ -200,15 +287,33 @@ ds = Dataset(root_dir="az://container/path", dataset_name="my_data", fs=fs)
 
 ## General Pattern
 
-For any cloud provider, the pattern is:
+For any cloud provider, the recommended pattern is:
 
-1. **Auto-detect (works if credentials are already configured)**:
+1. **New Cloud-Agnostic Approach (Recommended)**:
 
    ```python
-   ds = Dataset(root_dir="protocol://bucket/path", dataset_name="my_data")
+   from kirin import Catalog, Dataset
+
+   # For AWS/S3
+   catalog = Catalog(root_dir="s3://bucket/path", aws_profile="my-profile")
+   dataset = Dataset(root_dir="s3://bucket/path", name="my_data", aws_profile="my-profile")
+
+   # For GCS
+   catalog = Catalog(root_dir="gs://bucket/path", gcs_token="/path/to/key.json", gcs_project="my-project")
+   dataset = Dataset(root_dir="gs://bucket/path", name="my_data", gcs_token="/path/to/key.json", gcs_project="my-project")
+
+   # For Azure
+   catalog = Catalog(root_dir="az://container/path", azure_connection_string="...")
+   dataset = Dataset(root_dir="az://container/path", name="my_data", azure_connection_string="...")
    ```
 
-2. **Explicit authentication (recommended for production)**:
+2. **Auto-detect (works if credentials are already configured)**:
+
+   ```python
+   ds = Dataset(root_dir="protocol://bucket/path", name="my_data")
+   ```
+
+3. **Legacy explicit authentication (still supported)**:
 
    ```python
    import fsspec
@@ -218,7 +323,7 @@ For any cloud provider, the pattern is:
    fs = fsspec.filesystem('protocol', **auth_kwargs)
 
    # Pass to Dataset
-   ds = Dataset(root_dir="protocol://bucket/path", dataset_name="my_data", fs=fs)
+   ds = Dataset(root_dir="protocol://bucket/path", name="my_data", fs=fs)
    ```
 
 ## Testing Without Credentials

--- a/kirin/catalog.py
+++ b/kirin/catalog.py
@@ -1,6 +1,7 @@
 """Lightweight implementation of a Data Catalog, which is a collection of Datasets."""
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List, Optional, Union
 
 import fsspec
@@ -16,6 +17,15 @@ class Catalog:
 
     root_dir: Union[str, fsspec.AbstractFileSystem]
     fs: Optional[fsspec.AbstractFileSystem] = None
+    # AWS/S3 authentication
+    aws_profile: Optional[str] = None
+    # GCP/GCS authentication
+    gcs_token: Optional[Union[str, Path]] = None
+    gcs_project: Optional[str] = None
+    # Azure authentication
+    azure_account_name: Optional[str] = None
+    azure_account_key: Optional[str] = None
+    azure_connection_string: Optional[str] = None
 
     def __post_init__(self):
         """Post-initialization function for the Catalog class."""
@@ -25,7 +35,15 @@ class Catalog:
             self.root_dir = self.fs.root_marker
         else:
             self.root_dir = str(self.root_dir)
-            self.fs = self.fs or get_filesystem(self.root_dir)
+            self.fs = self.fs or get_filesystem(
+                self.root_dir,
+                aws_profile=self.aws_profile,
+                gcs_token=self.gcs_token,
+                gcs_project=self.gcs_project,
+                azure_account_name=self.azure_account_name,
+                azure_account_key=self.azure_account_key,
+                azure_connection_string=self.azure_connection_string,
+            )
 
         # Set up datasets directory path
         self.datasets_dir = f"{strip_protocol(self.root_dir)}/datasets"

--- a/kirin/dataset.py
+++ b/kirin/dataset.py
@@ -56,11 +56,28 @@ class Dataset:
         name: str,
         description: str = "",
         fs: Optional[fsspec.AbstractFileSystem] = None,
+        # AWS/S3 authentication
+        aws_profile: Optional[str] = None,
+        # GCP/GCS authentication
+        gcs_token: Optional[Union[str, Path]] = None,
+        gcs_project: Optional[str] = None,
+        # Azure authentication
+        azure_account_name: Optional[str] = None,
+        azure_account_key: Optional[str] = None,
+        azure_connection_string: Optional[str] = None,
     ):
         self.root_dir = str(root_dir)
         self.name = name
         self.description = description
-        self.fs = fs or get_filesystem(self.root_dir)
+        self.fs = fs or get_filesystem(
+            self.root_dir,
+            aws_profile=aws_profile,
+            gcs_token=gcs_token,
+            gcs_project=gcs_project,
+            azure_account_name=azure_account_name,
+            azure_account_key=azure_account_key,
+            azure_connection_string=azure_connection_string,
+        )
 
         # Initialize storage and commit store
         self.storage = ContentStore(self.root_dir, self.fs)

--- a/kirin/web/app.py
+++ b/kirin/web/app.py
@@ -19,7 +19,6 @@ from fastapi.templating import Jinja2Templates
 from loguru import logger
 from slugify import slugify
 
-from .. import Catalog
 from .config import CatalogConfig, CatalogManager
 
 # Global catalog manager
@@ -240,8 +239,7 @@ async def list_datasets(
 
     try:
         # Create authenticated filesystem and load datasets automatically
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
         dataset_names = kirin_catalog.datasets()
 
         # Simple dataset info - no expensive operations
@@ -299,8 +297,7 @@ async def create_dataset(
 
     try:
         # Create authenticated filesystem before creating Catalog
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
 
         # Check if dataset exists like notebook
         existing_datasets = kirin_catalog.datasets()
@@ -436,8 +433,7 @@ async def delete_catalog_confirmation(
 
     # Get dataset count for this catalog
     try:
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
         dataset_count = len(kirin_catalog.datasets())
     except Exception as e:
         logger.warning(f"Failed to get dataset count for catalog {catalog_id}: {e}")
@@ -467,8 +463,7 @@ async def delete_catalog(
 
         # Check if catalog has datasets
         try:
-            fs = catalog_manager.create_filesystem(catalog)
-            kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+            kirin_catalog = catalog.to_catalog()
             datasets = kirin_catalog.datasets()
             if datasets:
                 raise HTTPException(
@@ -521,8 +516,7 @@ async def view_dataset(
             raise HTTPException(status_code=404, detail="Catalog not found")
 
         # Create authenticated filesystem before creating Catalog
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
         dataset = kirin_catalog.get_dataset(dataset_name)
 
         # Get files like notebook: dataset.list_files()
@@ -575,8 +569,7 @@ async def dataset_files_tab(request: Request, catalog_id: str, dataset_name: str
     try:
         # Create authenticated filesystem before creating Catalog
         catalog = catalog_manager.get_catalog(catalog_id)
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
         dataset = kirin_catalog.get_dataset(dataset_name)
 
         # Get files like notebook: dataset.list_files()
@@ -623,8 +616,7 @@ async def dataset_history_tab(request: Request, catalog_id: str, dataset_name: s
     try:
         # Create authenticated filesystem before creating Catalog
         catalog = catalog_manager.get_catalog(catalog_id)
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
         dataset = kirin_catalog.get_dataset(dataset_name)
 
         # Get commit history like notebook: dataset.history()
@@ -672,8 +664,7 @@ async def commit_form(request: Request, catalog_id: str, dataset_name: str):
     try:
         # Create authenticated filesystem before creating Catalog
         catalog = catalog_manager.get_catalog(catalog_id)
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
         dataset = kirin_catalog.get_dataset(dataset_name)
 
         # Get current files for removal selection
@@ -718,8 +709,7 @@ async def create_commit(
     try:
         # Create authenticated filesystem before creating Catalog
         catalog = catalog_manager.get_catalog(catalog_id)
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
         dataset = kirin_catalog.get_dataset(dataset_name)
 
         # Handle file uploads
@@ -809,8 +799,7 @@ async def preview_file(
         if not catalog:
             raise HTTPException(status_code=404, detail="Catalog not found")
 
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
         dataset = kirin_catalog.get_dataset(dataset_name)
         file_obj = dataset.get_file(file_name)
 
@@ -919,8 +908,7 @@ async def download_file(catalog_id: str, dataset_name: str, file_name: str):
         if not catalog:
             raise HTTPException(status_code=404, detail="Catalog not found")
 
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
         dataset = kirin_catalog.get_dataset(dataset_name)
         file_obj = dataset.get_file(file_name)
 
@@ -976,8 +964,7 @@ async def checkout_commit(
         if not catalog:
             raise HTTPException(status_code=404, detail="Catalog not found")
 
-        fs = catalog_manager.create_filesystem(catalog)
-        kirin_catalog = Catalog(catalog.root_dir, fs=fs)
+        kirin_catalog = catalog.to_catalog()
         dataset = kirin_catalog.get_dataset(dataset_name)
 
         try:

--- a/notebooks/catalog_demo.py
+++ b/notebooks/catalog_demo.py
@@ -462,7 +462,7 @@ def _(catalog, mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
     str_catalog_benefits = ""
     str_catalog_benefits += "**Kirin Catalog Benefits:**\n\n"
@@ -553,7 +553,7 @@ def _(mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
     str_use_cases = ""
     str_use_cases += "**Common Catalog Use Cases:**\n\n"
@@ -584,7 +584,7 @@ def _(mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
     # Demonstrate Catalog with remote storage (GCS example)
     str_remote_catalog = ""
@@ -636,7 +636,13 @@ def _(Catalog, Path):
 
 
 @app.cell
-def _():
+def _(Catalog):
+    ormoni_catalog = Catalog(
+        root_dir="s3://ormoni-data-version-control-test",
+        aws_profile="ormoni-research",
+    )
+    ormoni_ds = ormoni_catalog.get_dataset("test-redirect")
+    ormoni_ds.list_files()
     return
 
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1728,13 +1728,13 @@ packages:
 - pypi: ./
   name: kirin
   version: 0.0.1
-  sha256: 9168203eb260615ac7f37abf24a13ae2dbb7060a135ed7550e932049d524b593
+  sha256: 49534bc752ef471ccd652a1a7bbd54c0a214a36bb475dbd2f12007203f594ea0
   requires_dist:
   - pyprojroot
   - python-dotenv
   - typer
   - json5
-  - fsspec
+  - fsspec>=2025.9.0,<2026
   - s3fs
   - gcsfs
   - fastapi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "python-dotenv",
     "typer",
     "json5",
-    "fsspec",
+    "fsspec>=2025.9.0,<2026",
     "s3fs",  # For S3 support
     "gcsfs",  # For Google Cloud Storage support
     "fastapi",

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,6 +1,7 @@
 """Tests for lightweight data catalogs."""
 
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -62,3 +63,124 @@ def test_create_dataset(empty_catalog):
 
     dataset = catalog.get_dataset("test_dataset")
     assert dataset.name == "test_dataset"
+
+
+class TestCatalogCloudAuth:
+    """Test Catalog class with cloud authentication parameters."""
+
+    def test_catalog_with_aws_profile(self, tmpdir):
+        """Test creating Catalog with AWS profile."""
+        with patch("kirin.catalog.get_filesystem") as mock_get_filesystem:
+            mock_fs = Mock()
+            mock_get_filesystem.return_value = mock_fs
+
+            catalog = Catalog(root_dir="s3://bucket/path", aws_profile="test-profile")
+
+            # Verify get_filesystem was called with AWS profile
+            mock_get_filesystem.assert_called_once_with(
+                "s3://bucket/path",
+                aws_profile="test-profile",
+                gcs_token=None,
+                gcs_project=None,
+                azure_account_name=None,
+                azure_account_key=None,
+                azure_connection_string=None,
+            )
+            assert catalog.fs == mock_fs
+
+    def test_catalog_with_gcs_credentials(self, tmpdir):
+        """Test creating Catalog with GCS credentials."""
+        with patch("kirin.catalog.get_filesystem") as mock_get_filesystem:
+            mock_fs = Mock()
+            mock_get_filesystem.return_value = mock_fs
+
+            catalog = Catalog(
+                root_dir="gs://bucket/path",
+                gcs_token="/path/to/service-account.json",
+                gcs_project="test-project",
+            )
+
+            # Verify get_filesystem was called with GCS credentials
+            mock_get_filesystem.assert_called_once_with(
+                "gs://bucket/path",
+                aws_profile=None,
+                gcs_token="/path/to/service-account.json",
+                gcs_project="test-project",
+                azure_account_name=None,
+                azure_account_key=None,
+                azure_connection_string=None,
+            )
+            assert catalog.fs == mock_fs
+
+    def test_catalog_with_azure_credentials(self, tmpdir):
+        """Test creating Catalog with Azure credentials."""
+        with patch("kirin.catalog.get_filesystem") as mock_get_filesystem:
+            mock_fs = Mock()
+            mock_get_filesystem.return_value = mock_fs
+
+            catalog = Catalog(
+                root_dir="az://container/path",
+                azure_account_name="test-account",
+                azure_account_key="test-key",
+                azure_connection_string="test-connection",
+            )
+
+            # Verify get_filesystem was called with Azure credentials
+            mock_get_filesystem.assert_called_once_with(
+                "az://container/path",
+                aws_profile=None,
+                gcs_token=None,
+                gcs_project=None,
+                azure_account_name="test-account",
+                azure_account_key="test-key",
+                azure_connection_string="test-connection",
+            )
+            assert catalog.fs == mock_fs
+
+    def test_catalog_backward_compatibility(self, tmpdir):
+        """Test that existing code without auth parameters still works."""
+        with patch("kirin.catalog.get_filesystem") as mock_get_filesystem:
+            mock_fs = Mock()
+            mock_get_filesystem.return_value = mock_fs
+
+            # Test local path (should not use any cloud auth)
+            catalog = Catalog(root_dir=Path(tmpdir))
+
+            # Verify get_filesystem was called with None for all auth params
+            mock_get_filesystem.assert_called_once_with(
+                str(Path(tmpdir)),
+                aws_profile=None,
+                gcs_token=None,
+                gcs_project=None,
+                azure_account_name=None,
+                azure_account_key=None,
+                azure_connection_string=None,
+            )
+            assert catalog.fs == mock_fs
+
+    def test_catalog_with_mixed_auth_params(self, tmpdir):
+        """Test that only relevant auth parameters are used for each protocol."""
+        with patch("kirin.catalog.get_filesystem") as mock_get_filesystem:
+            mock_fs = Mock()
+            mock_get_filesystem.return_value = mock_fs
+
+            # Test S3 with mixed params - only AWS should be used
+            catalog = Catalog(
+                root_dir="s3://bucket/path",
+                aws_profile="aws-profile",
+                gcs_token="gcs-token",  # Should be ignored
+                azure_account_name="azure-account",  # Should be ignored
+            )
+
+            # Verify get_filesystem was called with all params
+            # (filtering happens inside)
+            mock_get_filesystem.assert_called_once_with(
+                "s3://bucket/path",
+                aws_profile="aws-profile",
+                gcs_token="gcs-token",
+                gcs_project=None,
+                azure_account_name="azure-account",
+                azure_account_key=None,
+                azure_connection_string=None,
+            )
+            assert catalog.fs == mock_fs

--- a/tests/test_cloud_auth_integration.py
+++ b/tests/test_cloud_auth_integration.py
@@ -1,0 +1,251 @@
+"""Tests for cloud authentication integration in get_filesystem()."""
+
+from unittest.mock import Mock, patch
+
+from kirin.utils import get_filesystem
+
+
+class TestGetFilesystemCloudAuth:
+    """Test cloud authentication parameter passing in get_filesystem()."""
+
+    def test_get_filesystem_aws_profile_passing(self):
+        """Test that AWS profile parameter is passed through correctly."""
+        with patch("kirin.utils._get_s3_filesystem_with_credentials") as mock_s3:
+            mock_fs = Mock()
+            mock_s3.return_value = mock_fs
+
+            # Test S3 path with AWS profile
+            result = get_filesystem("s3://bucket/path", aws_profile="test-profile")
+
+            # Verify the helper was called with the profile
+            mock_s3.assert_called_once_with("test-profile")
+            assert result == mock_fs
+
+    def test_get_filesystem_gcs_token_project_passing(self):
+        """Test that GCS token and project parameters are passed through correctly."""
+        with patch("kirin.utils._get_gcs_filesystem_with_credentials") as mock_gcs:
+            mock_fs = Mock()
+            mock_gcs.return_value = mock_fs
+
+            # Test GCS path with token and project
+            result = get_filesystem(
+                "gs://bucket/path",
+                gcs_token="/path/to/service-account.json",
+                gcs_project="test-project"
+            )
+
+            # Verify the helper was called with the parameters
+            mock_gcs.assert_called_once_with(
+                token="/path/to/service-account.json",
+                project="test-project"
+            )
+            assert result == mock_fs
+
+    def test_get_filesystem_azure_credentials_passing(self):
+        """Test that Azure credentials are passed through correctly."""
+        with patch("kirin.utils._get_azure_filesystem_with_credentials") as mock_azure:
+            mock_fs = Mock()
+            mock_azure.return_value = mock_fs
+
+            # Test Azure path with credentials
+            result = get_filesystem(
+                "az://container/path",
+                azure_account_name="test-account",
+                azure_account_key="test-key",
+                azure_connection_string="test-connection"
+            )
+
+            # Verify the helper was called with the parameters
+            mock_azure.assert_called_once_with(
+                account_name="test-account",
+                account_key="test-key",
+                connection_string="test-connection"
+            )
+            assert result == mock_fs
+
+    def test_get_filesystem_backward_compatibility(self):
+        """Test that existing code without auth parameters still works."""
+        with patch("kirin.utils._get_s3_filesystem_with_credentials") as mock_s3:
+            mock_fs = Mock()
+            mock_s3.return_value = mock_fs
+
+            # Test S3 path without any auth parameters (should use default)
+            result = get_filesystem("s3://bucket/path")
+
+            # Verify the helper was called with None (default)
+            mock_s3.assert_called_once_with(None)
+            assert result == mock_fs
+
+    def test_get_filesystem_local_path_ignores_auth_params(self):
+        """Test that local paths ignore cloud auth parameters."""
+        with patch("fsspec.filesystem") as mock_fsspec:
+            mock_fs = Mock()
+            mock_fsspec.return_value = mock_fs
+
+            # Test local path with auth parameters (should be ignored)
+            result = get_filesystem(
+                "/local/path",
+                aws_profile="test-profile",
+                gcs_token="test-token",
+                azure_account_name="test-account"
+            )
+
+            # Verify fsspec was called with 'file' protocol only
+            mock_fsspec.assert_called_once_with("file")
+            assert result == mock_fs
+
+    def test_get_filesystem_unsupported_protocol_ignores_auth_params(self):
+        """Test that unsupported protocols ignore cloud auth parameters."""
+        with patch("fsspec.filesystem") as mock_fsspec:
+            mock_fs = Mock()
+            mock_fsspec.return_value = mock_fs
+
+            # Test unsupported protocol with auth parameters (should be ignored)
+            result = get_filesystem(
+                "ftp://server/path",
+                aws_profile="test-profile",
+                gcs_token="test-token",
+                azure_account_name="test-account"
+            )
+
+            # Verify fsspec was called with the protocol only
+            mock_fsspec.assert_called_once_with("ftp")
+            assert result == mock_fs
+
+    def test_get_filesystem_mixed_auth_params(self):
+        """Test that only relevant auth parameters are passed to each protocol."""
+        # Test S3 with mixed params - only AWS should be used
+        with patch("kirin.utils._get_s3_filesystem_with_credentials") as mock_s3:
+            mock_fs = Mock()
+            mock_s3.return_value = mock_fs
+
+            result = get_filesystem(
+                "s3://bucket/path",
+                aws_profile="aws-profile",
+                gcs_token="gcs-token",  # Should be ignored
+                azure_account_name="azure-account"  # Should be ignored
+            )
+
+            # Only AWS profile should be passed
+            mock_s3.assert_called_once_with("aws-profile")
+            assert result == mock_fs
+
+        # Test GCS with mixed params - only GCS should be used
+        with patch("kirin.utils._get_gcs_filesystem_with_credentials") as mock_gcs:
+            mock_fs = Mock()
+            mock_gcs.return_value = mock_fs
+
+            result = get_filesystem(
+                "gs://bucket/path",
+                aws_profile="aws-profile",  # Should be ignored
+                gcs_token="gcs-token",
+                gcs_project="gcs-project",
+                azure_account_name="azure-account"  # Should be ignored
+            )
+
+            # Only GCS params should be passed
+            mock_gcs.assert_called_once_with(
+                token="gcs-token",
+                project="gcs-project"
+            )
+            assert result == mock_fs
+
+    def test_get_filesystem_azure_with_mixed_params(self):
+        """Test Azure with mixed params - only Azure should be used."""
+        with patch("kirin.utils._get_azure_filesystem_with_credentials") as mock_azure:
+            mock_fs = Mock()
+            mock_azure.return_value = mock_fs
+
+            result = get_filesystem(
+                "az://container/path",
+                aws_profile="aws-profile",  # Should be ignored
+                gcs_token="gcs-token",  # Should be ignored
+                azure_account_name="azure-account",
+                azure_account_key="azure-key"
+            )
+
+            # Only Azure params should be passed
+            mock_azure.assert_called_once_with(
+                account_name="azure-account",
+                account_key="azure-key",
+                connection_string=None
+            )
+            assert result == mock_fs
+
+
+class TestCloudAuthHelpers:
+    """Test the cloud authentication helper functions."""
+
+    def test_get_gcs_filesystem_with_credentials(self):
+        """Test GCS helper function calls cloud_auth.get_gcs_filesystem correctly."""
+        with patch("kirin.cloud_auth.get_gcs_filesystem") as mock_get_gcs:
+            mock_fs = Mock()
+            mock_get_gcs.return_value = mock_fs
+
+            from kirin.utils import _get_gcs_filesystem_with_credentials
+
+            result = _get_gcs_filesystem_with_credentials(
+                token="/path/to/service-account.json",
+                project="test-project"
+            )
+
+            # Verify cloud_auth.get_gcs_filesystem was called with correct params
+            mock_get_gcs.assert_called_once_with(
+                token="/path/to/service-account.json",
+                project="test-project"
+            )
+            assert result == mock_fs
+
+    def test_get_gcs_filesystem_with_credentials_none_params(self):
+        """Test GCS helper function with None parameters."""
+        with patch("kirin.cloud_auth.get_gcs_filesystem") as mock_get_gcs:
+            mock_fs = Mock()
+            mock_get_gcs.return_value = mock_fs
+
+            from kirin.utils import _get_gcs_filesystem_with_credentials
+
+            result = _get_gcs_filesystem_with_credentials()
+
+            # Verify cloud_auth.get_gcs_filesystem was called with None params
+            mock_get_gcs.assert_called_once_with(token=None, project=None)
+            assert result == mock_fs
+
+    def test_get_azure_filesystem_with_credentials(self):
+        """Test Azure helper function calls cloud_auth.get_azure_filesystem."""
+        with patch("kirin.cloud_auth.get_azure_filesystem") as mock_get_azure:
+            mock_fs = Mock()
+            mock_get_azure.return_value = mock_fs
+
+            from kirin.utils import _get_azure_filesystem_with_credentials
+
+            result = _get_azure_filesystem_with_credentials(
+                account_name="test-account",
+                account_key="test-key",
+                connection_string="test-connection"
+            )
+
+            # Verify cloud_auth.get_azure_filesystem was called with correct params
+            mock_get_azure.assert_called_once_with(
+                account_name="test-account",
+                account_key="test-key",
+                connection_string="test-connection"
+            )
+            assert result == mock_fs
+
+    def test_get_azure_filesystem_with_credentials_none_params(self):
+        """Test Azure helper function with None parameters."""
+        with patch("kirin.cloud_auth.get_azure_filesystem") as mock_get_azure:
+            mock_fs = Mock()
+            mock_get_azure.return_value = mock_fs
+
+            from kirin.utils import _get_azure_filesystem_with_credentials
+
+            result = _get_azure_filesystem_with_credentials()
+
+            # Verify cloud_auth.get_azure_filesystem was called with None params
+            mock_get_azure.assert_called_once_with(
+                account_name=None,
+                account_key=None,
+                connection_string=None
+            )
+            assert result == mock_fs

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,7 @@
 """Tests for the kirin.dataset.Dataset class."""
 
+from unittest.mock import Mock, patch
+
 import pytest
 
 from kirin.dataset import Dataset
@@ -153,3 +155,134 @@ def test_file_dict(request, ds_name):
         assert len(file_dict) == len(ds.current_commit.files)
     else:
         assert len(file_dict) == 0
+
+
+def test_dataset_with_aws_profile(tmp_path):
+    """Test creating Dataset with AWS profile."""
+    with patch("kirin.dataset.get_filesystem") as mock_get_filesystem:
+        mock_fs = Mock()
+        mock_fs.exists.return_value = False  # No commits file exists
+        mock_get_filesystem.return_value = mock_fs
+
+        dataset = Dataset(
+            root_dir="s3://bucket/path", name="test-dataset", aws_profile="test-profile"
+        )
+
+        # Verify get_filesystem was called with AWS profile
+        mock_get_filesystem.assert_called_once_with(
+            "s3://bucket/path",
+            aws_profile="test-profile",
+            gcs_token=None,
+            gcs_project=None,
+            azure_account_name=None,
+            azure_account_key=None,
+            azure_connection_string=None,
+        )
+        assert dataset.fs == mock_fs
+
+
+def test_dataset_with_gcs_credentials(tmp_path):
+    """Test creating Dataset with GCS credentials."""
+    with patch("kirin.dataset.get_filesystem") as mock_get_filesystem:
+        mock_fs = Mock()
+        mock_fs.exists.return_value = False  # No commits file exists
+        mock_get_filesystem.return_value = mock_fs
+
+        dataset = Dataset(
+            root_dir="gs://bucket/path",
+            name="test-dataset",
+            gcs_token="/path/to/service-account.json",
+            gcs_project="test-project",
+        )
+
+        # Verify get_filesystem was called with GCS credentials
+        mock_get_filesystem.assert_called_once_with(
+            "gs://bucket/path",
+            aws_profile=None,
+            gcs_token="/path/to/service-account.json",
+            gcs_project="test-project",
+            azure_account_name=None,
+            azure_account_key=None,
+            azure_connection_string=None,
+        )
+        assert dataset.fs == mock_fs
+
+
+def test_dataset_with_azure_credentials(tmp_path):
+    """Test creating Dataset with Azure credentials."""
+    with patch("kirin.dataset.get_filesystem") as mock_get_filesystem:
+        mock_fs = Mock()
+        mock_fs.exists.return_value = False  # No commits file exists
+        mock_get_filesystem.return_value = mock_fs
+
+        dataset = Dataset(
+            root_dir="az://container/path",
+            name="test-dataset",
+            azure_account_name="test-account",
+            azure_account_key="test-key",
+            azure_connection_string="test-connection",
+        )
+
+        # Verify get_filesystem was called with Azure credentials
+        mock_get_filesystem.assert_called_once_with(
+            "az://container/path",
+            aws_profile=None,
+            gcs_token=None,
+            gcs_project=None,
+            azure_account_name="test-account",
+            azure_account_key="test-key",
+            azure_connection_string="test-connection",
+        )
+        assert dataset.fs == mock_fs
+
+
+def test_dataset_backward_compatibility(tmp_path):
+    """Test that existing code without auth parameters still works."""
+    with patch("kirin.dataset.get_filesystem") as mock_get_filesystem:
+        mock_fs = Mock()
+        mock_fs.exists.return_value = False  # No commits file exists
+        mock_get_filesystem.return_value = mock_fs
+
+        # Test local path (should not use any cloud auth)
+        dataset = Dataset(root_dir=tmp_path, name="test-dataset")
+
+        # Verify get_filesystem was called with None for all auth params
+        mock_get_filesystem.assert_called_once_with(
+            str(tmp_path),
+            aws_profile=None,
+            gcs_token=None,
+            gcs_project=None,
+            azure_account_name=None,
+            azure_account_key=None,
+            azure_connection_string=None,
+        )
+        assert dataset.fs == mock_fs
+
+
+def test_dataset_with_mixed_auth_params(tmp_path):
+    """Test that only relevant auth parameters are used for each protocol."""
+    with patch("kirin.dataset.get_filesystem") as mock_get_filesystem:
+        mock_fs = Mock()
+        mock_fs.exists.return_value = False  # No commits file exists
+        mock_get_filesystem.return_value = mock_fs
+
+        # Test S3 with mixed params - only AWS should be used
+        dataset = Dataset(
+            root_dir="s3://bucket/path",
+            name="test-dataset",
+            aws_profile="aws-profile",
+            gcs_token="gcs-token",  # Should be ignored
+            azure_account_name="azure-account",  # Should be ignored
+        )
+
+        # Verify get_filesystem was called with all params (filtering happens inside)
+        mock_get_filesystem.assert_called_once_with(
+            "s3://bucket/path",
+            aws_profile="aws-profile",
+            gcs_token="gcs-token",
+            gcs_project=None,
+            azure_account_name="azure-account",
+            azure_account_key=None,
+            azure_connection_string=None,
+        )
+        assert dataset.fs == mock_fs


### PR DESCRIPTION
…atalog, Dataset, and web UI

- Add cloud authentication parameters to Catalog and Dataset constructors.
- Update get_filesystem utility to support S3, GCS, and Azure authentication.
- Refactor web UI to use CatalogConfig.to_catalog() for cloud auth.
- Update docs and examples for new cloud-agnostic authentication pattern.
- Add and update tests for cloud authentication and backward compatibility.
- Pin fsspec dependency to >=2025.9.0,<2026 for compatibility.