### PR TITLE
docs(cursor-commands)📝: Update command documentation to reflect staging instead of committing changes

### DIFF
--- a/.cursor/commands/branch-and-commit.md
+++ b/.cursor/commands/branch-and-commit.md
@@ -1,1 +1,0 @@
-Given everything we just did, or given what you see when you run git diff, give me a new git branch and git add and commit all the changes. You do not need to give me a commit message, I have a git commit message writer. If there are any commit

--- a/.cursor/commands/branch-and-stage.md
+++ b/.cursor/commands/branch-and-stage.md
@@ -1,0 +1,1 @@
+Given everything we just did, or given what you see when you run git diff, give me a new git branch and git add to stage all the changes. You do not need to give me a commit message, I have a git commit message writer.


### PR DESCRIPTION
- Remove branch-and-commit.md which referenced committing changes.
- Add branch-and-stage.md to instruct on staging changes instead of committing.