### PR TITLE
ci(docs)🛠️: update docs workflow to use new build-docs task and add d…

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,9 +20,7 @@ jobs:
           environments: docs
 
       - name: Build docs
-        run: |
-          pixi run cli-docs
-          pixi run build-docs
+        run: pixi run build-docs
 
       - name: Deploy website
         uses: peaceiris/actions-gh-pages@v4

--- a/pixi.lock
+++ b/pixi.lock
@@ -1873,7 +1873,7 @@ packages:
 - pypi: ./
   name: kirin
   version: 0.0.1
-  sha256: 05ddb6fd04fc5aec60fe15f04b1b85c1413a4262d3a499d6368f949f85788ce3
+  sha256: 0e4c92095b07804a2b86ca1396c14aae4687b46b4ef0735444f6d29fdb622738
   requires_dist:
   - pyprojroot
   - python-dotenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,9 @@ tests = { features = ["tests"], solve-group = "default" }
 [tool.pixi.feature.tests.tasks]
 test = "pytest --durations=10 --tb=short -v"
 
+[tool.pixi.feature.docs.tasks]
+build-docs = "mkdocs build --clean"
+
 
 [tool.pixi.tasks]
 setup-ssl = "python -m kirin.setup_ssl"


### PR DESCRIPTION
…ocs feature to pixi config

- Remove cli-docs step from GitHub Actions docs workflow and use only build-docs.
- Add docs feature and build-docs task to pyproject.toml for Pixi.
- Update pixi.lock to reflect changes in project configuration.