### PR TITLE
Update CLI and web app to allow customizable host binding for the Kir…

### DIFF
--- a/kirin/cli.py
+++ b/kirin/cli.py
@@ -19,17 +19,23 @@ def find_free_port() -> int:
     return port
 
 
-def ui() -> None:
+def ui(
+    host: str = typer.Option(
+        "localhost", help="Host to bind to (use 0.0.0.0 for Docker)"
+    ),
+    port: int = typer.Option(None, help="Port to bind to (random if not specified)"),
+) -> None:
     """Launch the Kirin web interface."""
-    port = find_free_port()
-    logger.info(f"Using random port: {port}")
+    if port is None:
+        port = find_free_port()
+        logger.info(f"Using random port: {port}")
 
-    logger.info(f"Starting Kirin web interface on 127.0.0.1:{port}")
+    logger.info(f"Starting Kirin web interface on {host}:{port}")
     logger.info("PERF: Web interface starting with auto-reload enabled")
 
     uvicorn.run(
         "kirin.web.app:app",
-        host="127.0.0.1",
+        host=host,
         port=port,
         reload=True,  # Auto-reload enabled per user preference
         log_level="info",

--- a/kirin/web/app.py
+++ b/kirin/web/app.py
@@ -1029,4 +1029,4 @@ async def checkout_commit(
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run(app, host="localhost", port=8000, reload=True)


### PR DESCRIPTION
…in web interface. The `ui` function in `cli.py` now accepts a `host` parameter, defaulting to "localhost", and logs the starting address. The web app's main execution also binds to "localhost" instead of "0.0.0.0".