### PR TITLE
feat(model-versioning)🆕: add model versioning support with metadata and tags to commits and dataset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,7 @@ components. When working on the web UI:
 ### CSS Architecture & Best Practices
 
 **External Stylesheet System** - The project uses a centralized CSS
-architecture with all common styles in `/gitdata/static/styles.css`:
+architecture with all common styles in `/kirin/static/styles.css`:
 
 - **Base Template** - `base.html` includes the external stylesheet via
   `<link rel="stylesheet" href="/static/styles.css">`
@@ -351,23 +351,44 @@ architecture with all common styles in `/gitdata/static/styles.css`:
 
 ### Linting Guidelines
 
-**IMPORTANT**: Only fix linting errors that cannot be automatically fixed by
-linters like ruff. The project has pre-commit hooks that handle automatic
-linting fixes (formatting, import sorting, etc.). Focus on:
+**CRITICAL**: Always run pre-commit on all files and fix all issues. This
+ensures code quality and consistency across the entire codebase.
 
-- Logic errors and bugs that require manual intervention
-- Issues that cannot be automatically resolved by linters
-- Code quality problems that need human judgment
+**Pre-commit Requirements**:
 
-**Do NOT fix**:
+- **Run pre-commit on all files**: Always run `pre-commit run --all-files`
+  before committing changes
+- **Fix all issues**: Every single issue that pre-commit reports must be fixed
+- **Zero tolerance**: No pre-commit errors are acceptable - all must be
+  resolved
+- **Re-run until clean**: Continue running pre-commit until all files pass with
+  zero errors
+- **Before committing**: Never commit files that have pre-commit errors
+
+**Pre-commit handles automatic fixes**:
 
 - Import sorting (handled by isort/ruff)
 - Code formatting (handled by black/ruff)
 - Line length issues (handled by formatters)
 - Whitespace and spacing (handled by formatters)
 
-The pre-commit hooks will automatically handle these formatting issues, so
-focus on substantive code improvements.
+**Manual fixes required**:
+
+- Logic errors and bugs that require manual intervention
+- Issues that cannot be automatically resolved by linters
+- Code quality problems that need human judgment
+
+**Workflow**:
+
+```bash
+# Run pre-commit on all files
+pre-commit run --all-files
+
+# If issues are found, fix them and re-run
+pre-commit run --all-files
+
+# Continue until all files pass
+```
 
 ### Logging Standards
 
@@ -412,12 +433,12 @@ across the project.
 ### Static File Serving
 
 The application is configured to serve static files from the
-`/gitdata/static/` directory:
+`/kirin/static/` directory:
 
-- **CSS Files** - Place all stylesheets in `/gitdata/static/` directory
+- **CSS Files** - Place all stylesheets in `/kirin/static/` directory
 - **Static Mount** - FastAPI StaticFiles is mounted at `/static` route
 - **CSS Reference** - Templates reference CSS via `/static/styles.css`
-- **Development** - Use `pixi run python -m gitdata.web_ui` to start the
+- **Development** - Use `pixi run python -m kirin.web.app` to start the
   server with auto-reload
 
 ### Pixi Environment Management
@@ -428,10 +449,10 @@ must be executed within the pixi environment:
 
 - **Testing Commands**: Always use `pixi run python -m pytest` or
   `pixi run python script.py`
-- **Development Server**: Use `pixi run python -m gitdata.web_ui` to start
+- **Development Server**: Use `pixi run python -m kirin.web.app` to start
   the server
-- **Kirin UI**: Use `pixi run gitdata ui` to run the Kirin web interface
-- **CLI Commands**: Use `pixi run python -m gitdata.cli` for command-line
+- **Kirin UI**: Use `pixi run kirin ui` to run the Kirin web interface
+- **CLI Commands**: Use `pixi run python -m kirin.cli` for command-line
   operations
 
 **Dependency Management**: For core runtime dependencies, use
@@ -762,21 +783,21 @@ proper dependency resolution.
 # requires-python = ">=3.13"
 # dependencies = [
 #     "polars==1.34.0",
-#     "gitdata==0.0.1",
+#     "kirin==0.0.1",
 #     "anthropic==0.69.0",
 #     "loguru==0.7.3",
 # ]
 #
 # [tool.uv.sources]
-# gitdata = { path = "../", editable = true }
+# kirin = { path = "../", editable = true }
 # ///
 ```
 
 **Key Requirements**:
 
 - **Python Version**: Always specify `requires-python = ">=3.13"`
-- **Kirin Dependency**: Include `gitdata==0.0.1` in dependencies
-- **Editable Source**: Use `[tool.uv.sources]` with `gitdata = { path =
+- **Kirin Dependency**: Include `kirin==0.0.1` in dependencies
+- **Editable Source**: Use `[tool.uv.sources]` with `kirin = { path =
   "../", editable = true }`
 - **Additional Dependencies**: Include any other libraries the script needs
 - **Metadata Block**: Must be at the very top of the file, before any
@@ -1386,8 +1407,10 @@ consistency and quality. This is mandatory for all markdown file changes.
    resolved
 4. **Re-run until clean**: Continue running markdownlint until the file
    passes with zero errors
-5. **Before committing**: Never commit a Markdown file that has markdownlint
-   errors
+5. **Run pre-commit**: Always run `pre-commit run --all-files` to ensure all
+   files (including markdown) pass validation
+6. **Before committing**: Never commit a Markdown file that has markdownlint
+   errors or pre-commit failures
 
 **BULK LINTING**: When working on multiple Markdown files, run markdownlint
 on all files at once to identify issues across the entire documentation

--- a/README.md
+++ b/README.md
@@ -172,20 +172,20 @@ pixi run python -m kirin.web.app
 
 ```bash
 # Install with uv
-uv tool install gitdata
+uv tool install kirin
 
 # Set up SSL certificates (one-time setup)
 uv run python -m kirin.setup_ssl
 
 # Start the web UI
-uv run gitdata ui
+uv run kirin ui
 ```
 
 ### Option 3: UVX (One-time Use)
 
 ```bash
 # Run directly with uvx
-uvx gitdata ui
+uvx kirin ui
 
 # If SSL issues occur, set up certificates
 uvx python -m kirin.setup_ssl
@@ -195,10 +195,10 @@ uvx python -m kirin.setup_ssl
 
 ```bash
 # Install with pip
-pip install gitdata
+pip install kirin
 
 # No SSL setup needed - uses system certificates
-gitdata ui
+kirin ui
 ```
 
 ## Get started for development

--- a/docs/guides/model-versioning.md
+++ b/docs/guides/model-versioning.md
@@ -1,0 +1,464 @@
+# Model Versioning with Kirin
+
+Kirin provides powerful model versioning capabilities that make it easy to
+track, compare, and manage machine learning models throughout their lifecycle.
+This guide shows you how to use Kirin for model versioning workflows.
+
+## Overview
+
+Model versioning with Kirin enables you to:
+
+- **Track model artifacts** alongside rich metadata (hyperparameters, metrics,
+  training info)
+- **Tag models** for different stages (dev, staging, production) or versions
+- **Query and discover** models by performance metrics, tags, or custom criteria
+- **Compare model versions** to understand what changed between iterations
+- **Maintain linear history** with simple, git-like semantics
+- **Store models anywhere** - local filesystem, S3, GCS, Azure, etc.
+
+## Basic Model Versioning Workflow
+
+### 1. Initialize a Model Registry
+
+```python
+from kirin import Dataset
+
+# Create a model registry (works with any storage backend)
+model_registry = Dataset(
+    root_dir="s3://my-bucket/models",  # or local path, GCS, Azure, etc.
+    name="sentiment_classifier"
+)
+```
+
+### 2. Save Your First Model
+
+```python
+import torch
+
+# Save your model files
+torch.save(model.state_dict(), "model_weights.pt")
+
+# Commit with metadata and tags
+commit_hash = model_registry.commit(
+    message="Initial baseline model",
+    add_files=["model_weights.pt", "config.json"],
+    metadata={
+        "framework": "pytorch",
+        "accuracy": 0.87,
+        "f1_score": 0.85,
+        "hyperparameters": {
+            "learning_rate": 0.001,
+            "epochs": 10,
+            "batch_size": 32
+        },
+        "training_data": "sentiment_v1",
+        "model_size_mb": 0.5
+    },
+    tags=["baseline", "v1.0"]
+)
+```
+
+### 3. Save Improved Models
+
+```python
+# Train an improved model
+# ... training code ...
+
+# Save improved model
+torch.save(improved_model.state_dict(), "model_weights_v2.pt")
+
+# Commit with updated metadata
+commit_hash = model_registry.commit(
+    message="Improved model with better regularization",
+    add_files=["model_weights_v2.pt"],
+    metadata={
+        "framework": "pytorch",
+        "accuracy": 0.92,  # Improved!
+        "f1_score": 0.90,
+        "hyperparameters": {
+            "learning_rate": 0.0005,
+            "epochs": 15,
+            "batch_size": 32,
+            "weight_decay": 0.01  # Added regularization
+        },
+        "training_data": "sentiment_v2",
+        "improvements": ["Better regularization", "More epochs"]
+    },
+    tags=["improved", "v2.0", "production"]
+)
+```
+
+## Querying and Discovery
+
+### Find Models by Tags
+
+```python
+# Find all production models
+production_models = model_registry.find_commits(tags=["production"])
+
+# Find models with multiple tags
+v2_models = model_registry.find_commits(tags=["v2.0", "production"])
+```
+
+### Find Models by Performance Metrics
+
+```python
+# Find high-accuracy models
+high_accuracy = model_registry.find_commits(
+    metadata_filter=lambda m: m.get("accuracy", 0) > 0.9
+)
+
+# Find models by framework
+pytorch_models = model_registry.find_commits(
+    metadata_filter=lambda m: m.get("framework") == "pytorch"
+)
+
+# Complex queries
+best_models = model_registry.find_commits(
+    tags=["production"],
+    metadata_filter=lambda m: (
+        m.get("accuracy", 0) > 0.9 and
+        m.get("f1_score", 0) > 0.85
+    )
+)
+```
+
+### Compare Model Versions
+
+```python
+# Compare two model versions
+comparison = model_registry.compare_commits(
+    "abc123def",  # First model hash
+    "xyz789ghi"   # Second model hash
+)
+
+print("Metadata changes:")
+print(comparison["metadata_diff"]["changed"])
+print("Tag changes:")
+print(comparison["tags_diff"])
+```
+
+## Loading and Using Models
+
+### Checkout Specific Model Version
+
+```python
+# Checkout a specific model version
+model_registry.checkout("abc123def")
+
+# Access files from that version
+with model_registry.local_files() as files:
+    # Files are lazily downloaded when accessed
+    model_path = files["model_weights.pt"]
+    config_path = files["config.json"]
+
+    # Load your model
+    model = torch.load(model_path)
+```
+
+### Get Model Information
+
+```python
+# Get current model info
+current_commit = model_registry.current_commit
+print(f"Model: {current_commit.message}")
+print(f"Accuracy: {current_commit.metadata['accuracy']}")
+print(f"Tags: {current_commit.tags}")
+
+# List all files in current version
+for filename in model_registry.list_files():
+    file_obj = model_registry.get_file(filename)
+    print(f"{filename}: {file_obj.size} bytes")
+```
+
+## Metadata Schema Conventions
+
+While Kirin doesn't enforce a specific schema, here are recommended conventions:
+
+### Core Model Information
+
+```python
+metadata = {
+    # Required
+    "framework": "pytorch",  # or "tensorflow", "sklearn", etc.
+    "version": "2.1.0",      # Semantic versioning
+
+    # Performance metrics
+    "accuracy": 0.92,
+    "f1_score": 0.90,
+    "precision": 0.91,
+    "recall": 0.89,
+
+    # Model configuration
+    "hyperparameters": {
+        "learning_rate": 0.001,
+        "epochs": 10,
+        "batch_size": 32,
+        "optimizer": "adam"
+    },
+
+    # Training information
+    "training_data": "dataset_v2",
+    "training_time_seconds": 1200,
+    "model_size_mb": 0.5,
+
+    # Optional: domain-specific info
+    "domain": "medical",
+    "use_cases": ["patient_feedback", "clinical_notes"]
+}
+```
+
+### Tag Conventions
+
+```python
+# Staging tags
+tags = ["dev", "staging", "production"]
+
+# Version tags
+tags = ["v1.0", "v2.0", "v2.1"]
+
+# Domain tags
+tags = ["medical", "financial", "general"]
+
+# Status tags
+tags = ["baseline", "improved", "experimental"]
+```
+
+## Advanced Patterns
+
+### Model Staging Pipeline
+
+```python
+# Development model
+dev_commit = model_registry.commit(
+    message="Experimental model with new architecture",
+    add_files=["model.pt"],
+    metadata={"accuracy": 0.88, "framework": "pytorch"},
+    tags=["dev", "experimental"]
+)
+
+# Promote to staging
+staging_commit = model_registry.commit(
+    message="Promote experimental model to staging",
+    add_files=["model.pt"],  # Same model, different tags
+    metadata={"accuracy": 0.88, "framework": "pytorch"},
+    tags=["staging", "v2.1-beta"]
+)
+
+# Promote to production
+prod_commit = model_registry.commit(
+    message="Release v2.1 to production",
+    add_files=["model.pt"],
+    metadata={"accuracy": 0.88, "framework": "pytorch"},
+    tags=["production", "v2.1"]
+)
+```
+
+### A/B Testing Models
+
+```python
+# Model A
+model_a = model_registry.commit(
+    message="Model A - Original architecture",
+    add_files=["model_a.pt"],
+    metadata={"accuracy": 0.89, "architecture": "original"},
+    tags=["ab-test", "model-a"]
+)
+
+# Model B
+model_b = model_registry.commit(
+    message="Model B - Improved architecture",
+    add_files=["model_b.pt"],
+    metadata={"accuracy": 0.92, "architecture": "improved"},
+    tags=["ab-test", "model-b"]
+)
+
+# Find A/B test models
+ab_models = model_registry.find_commits(tags=["ab-test"])
+```
+
+### Domain-Specific Models
+
+```python
+# General model
+general_model = model_registry.commit(
+    message="General sentiment classifier",
+    add_files=["general_model.pt"],
+    metadata={
+        "accuracy": 0.90,
+        "domain": "general",
+        "training_data": "general_reviews"
+    },
+    tags=["general", "v1.0"]
+)
+
+# Medical domain model
+medical_model = model_registry.commit(
+    message="Medical sentiment classifier",
+    add_files=["medical_model.pt"],
+    metadata={
+        "accuracy": 0.85,  # Lower on general data
+        "domain_accuracy": 0.94,  # Higher on medical data
+        "domain": "medical",
+        "training_data": "medical_reviews"
+    },
+    tags=["medical", "domain-specific", "v1.1"]
+)
+```
+
+## Best Practices
+
+### 1. Consistent Metadata Schema
+
+Define a standard metadata schema for your team:
+
+```python
+def create_model_metadata(accuracy, f1_score, hyperparams, training_info):
+    """Create standardized metadata for model commits."""
+    return {
+        "framework": "pytorch",
+        "accuracy": accuracy,
+        "f1_score": f1_score,
+        "hyperparameters": hyperparams,
+        "training_data": training_info["dataset"],
+        "training_time_seconds": training_info["duration"],
+        "model_size_mb": training_info["size_mb"],
+        "timestamp": datetime.now().isoformat()
+    }
+```
+
+### 2. Meaningful Commit Messages
+
+```python
+# Good commit messages
+"Initial baseline model - BERT fine-tuned on customer reviews"
+"Improved model v2.0 - Added regularization and more training data"
+"Hotfix v2.0.1 - Fixed tokenization bug in production model"
+"Domain adaptation - Medical sentiment classifier"
+
+# Avoid vague messages
+"Updated model"
+"New version"
+"Changes"
+```
+
+### 3. Tag Management
+
+Use consistent tagging strategies:
+
+```python
+# Semantic versioning
+tags = ["v1.0.0", "v1.1.0", "v2.0.0"]
+
+# Staging pipeline
+tags = ["dev", "staging", "production"]
+
+# Feature flags
+tags = ["feature-xyz", "experimental", "deprecated"]
+```
+
+### 4. Model Validation
+
+Always validate model performance before committing:
+
+```python
+def validate_model(model, test_data):
+    """Validate model before committing."""
+    accuracy = evaluate_model(model, test_data)
+    if accuracy < 0.8:
+        raise ValueError(f"Model accuracy {accuracy} below threshold")
+    return accuracy
+
+# Use in commit workflow
+accuracy = validate_model(model, test_data)
+model_registry.commit(
+    message="Validated model v2.0",
+    add_files=["model.pt"],
+    metadata={"accuracy": accuracy, "validated": True},
+    tags=["validated", "v2.0"]
+)
+```
+
+## Integration with ML Workflows
+
+### With Experiment Tracking
+
+```python
+# Log to both Kirin and your experiment tracker
+import wandb
+
+# Start experiment
+wandb.init(project="sentiment-classifier")
+
+# Train model
+model, metrics = train_model()
+
+# Log to experiment tracker
+wandb.log(metrics)
+
+# Commit to Kirin
+commit_hash = model_registry.commit(
+    message=f"Experiment {wandb.run.name}",
+    add_files=["model.pt"],
+    metadata={
+        **metrics,
+        "experiment_id": wandb.run.id,
+        "run_name": wandb.run.name
+    },
+    tags=["experiment", wandb.run.name]
+)
+```
+
+### With Model Serving
+
+```python
+# Deploy model from Kirin
+def deploy_model(commit_hash):
+    model_registry.checkout(commit_hash)
+
+    with model_registry.local_files() as files:
+        model = torch.load(files["model.pt"])
+        config = json.load(open(files["config.json"]))
+
+    # Deploy to your serving infrastructure
+    deploy_to_production(model, config)
+    print(f"Deployed model {commit_hash[:8]}")
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### My metadata isn't being saved
+
+Make sure you're passing the `metadata` parameter to `commit()`. Check
+that your metadata is JSON-serializable.
+
+#### Can't find my models with `find_commits()`
+
+Verify your filter function returns a boolean. Use
+`lambda m: m.get("key", default) > value` for safe access.
+
+#### Files aren't downloading with `local_files()`
+
+Files are lazily loaded. Access them through the dictionary:
+`local_files["filename"]` to trigger download.
+
+#### How do I migrate from other model versioning tools?
+
+Kirin can work alongside other tools. You can import models from MLflow,
+DVC, etc., by saving their artifacts and committing them to Kirin.
+
+### Performance Tips
+
+- Use `limit` parameter in `find_commits()` for large datasets
+- Store large models in cloud storage (S3, GCS) for better performance
+- Use `local_files()` context manager to ensure cleanup of temporary files
+- Consider using tags for frequently queried model categories
+
+## Next Steps
+
+- Explore the [API Reference](../reference/api.md) for detailed method documentation
+- Check out the [Model Versioning
+  Demo](../../notebooks/model_versioning_demo.py) for a complete example
+- Learn about [Cloud Storage Integration](cloud-storage.md) for production deployments

--- a/kirin/schemas.py
+++ b/kirin/schemas.py
@@ -1,4 +1,4 @@
-"""DataFrame schemas for gitdata.
+"""DataFrame schemas for kirin.
 
 DataFrame schemas are written using `pandera`.
 Check out `pandera` docs for more information.

--- a/kirin/utils.py
+++ b/kirin/utils.py
@@ -1,4 +1,4 @@
-"""Utilities for gitdata."""
+"""Utilities for kirin."""
 
 import os
 from pathlib import Path

--- a/notebooks/gitdata_linear_workflow_demo.py
+++ b/notebooks/gitdata_linear_workflow_demo.py
@@ -1,12 +1,12 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "gitdata==0.0.1",
+#     "kirin==0.0.1",
 #     "loguru==0.7.3",
 # ]
 #
 # [tool.uv.sources]
-# gitdata = { path = "../", editable = true }
+# kirin = { path = "../", editable = true }
 # ///
 
 import marimo
@@ -24,9 +24,9 @@ def _():
 
 @app.cell
 def _(mo):
-    """# GitData: Linear Workflow Demonstration
+    """# Kirin: Linear Workflow Demonstration
 
-    This notebook demonstrates how to use **GitData** for version-controlled data management with a clean, linear commit history. GitData brings Git-like workflows to your data, enabling you to:
+    This notebook demonstrates how to use **Kirin** for version-controlled data management with a clean, linear commit history. Kirin brings Git-like workflows to your data, enabling you to:
 
     - 📁 **Track data changes** with commits and branches
     - 🔄 **Merge branches** using rebase strategy for linear history
@@ -39,9 +39,9 @@ def _(mo):
     In this demo, we'll create a dataset, make changes on feature branches, and merge them back to main using **rebase strategy** to maintain a clean, linear history without merge commits.
     """
     mo.md(
-        """# GitData: Linear Workflow Demonstration
+        """# Kirin: Linear Workflow Demonstration
 
-This notebook demonstrates how to use **GitData** for version-controlled data management with a clean, linear commit history. GitData brings Git-like workflows to your data, enabling you to:
+This notebook demonstrates how to use **Kirin** for version-controlled data management with a clean, linear commit history. Kirin brings Git-like workflows to your data, enabling you to:
 
 - 📁 **Track data changes** with commits and branches
 - 🔄 **Merge branches** using rebase strategy for linear history
@@ -60,12 +60,12 @@ In this demo, we'll create a dataset, make changes on feature branches, and merg
 def _(mo):
     """## Step 1: Dataset Setup
 
-    Let's start by creating a new GitData dataset with some initial files. This simulates the beginning of a data project where you have your base dataset ready for version control.
+    Let's start by creating a new Kirin dataset with some initial files. This simulates the beginning of a data project where you have your base dataset ready for version control.
     """
     mo.md(
         """## Step 1: Dataset Setup
 
-Let's start by creating a new GitData dataset with some initial files. This simulates the beginning of a data project where you have your base dataset ready for version control."""
+Let's start by creating a new Kirin dataset with some initial files. This simulates the beginning of a data project where you have your base dataset ready for version control."""
     )
     return
 
@@ -158,12 +158,12 @@ def _(dataset, temp_dir):
 def _(mo):
     """## Step 3: Rebase Merge Strategy
 
-    Here's where GitData shines! Instead of creating a merge commit (which would create a "branchy" history), we use the **rebase strategy** to replay our feature branch commits on top of main, creating a clean linear history.
+    Here's where Kirin shines! Instead of creating a merge commit (which would create a "branchy" history), we use the **rebase strategy** to replay our feature branch commits on top of main, creating a clean linear history.
     """
     mo.md(
         """## Step 3: Rebase Merge Strategy
 
-Here's where GitData shines! Instead of creating a merge commit (which would create a "branchy" history), we use the **rebase strategy** to replay our feature branch commits on top of main, creating a clean linear history."""
+Here's where Kirin shines! Instead of creating a merge commit (which would create a "branchy" history), we use the **rebase strategy** to replay our feature branch commits on top of main, creating a clean linear history."""
     )
     return
 
@@ -346,7 +346,7 @@ def _(dataset, mo):
 def _(mo):
     """## Key Takeaways
 
-    🎉 **Congratulations!** You've successfully demonstrated GitData's linear workflow capabilities:
+    🎉 **Congratulations!** You've successfully demonstrated Kirin's linear workflow capabilities:
 
     ### What We Accomplished:
     - ✅ Created a version-controlled dataset
@@ -364,12 +364,12 @@ def _(mo):
     ### Next Steps:
     - Try this workflow with your own datasets
     - Experiment with different merge strategies
-    - Explore GitData's other features
+    - Explore Kirin's other features
     """
     mo.md(
         """## Key Takeaways
 
-🎉 **Congratulations!** You've successfully demonstrated GitData's linear workflow capabilities:
+🎉 **Congratulations!** You've successfully demonstrated Kirin's linear workflow capabilities:
 
 ### What We Accomplished:
 - ✅ Created a version-controlled dataset
@@ -387,7 +387,7 @@ def _(mo):
 ### Next Steps:
 - Try this workflow with your own datasets
 - Experiment with different merge strategies
-- Explore GitData's other features"""
+- Explore Kirin's other features"""
     )
     return
 

--- a/notebooks/model_versioning_demo.py
+++ b/notebooks/model_versioning_demo.py
@@ -1,0 +1,591 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "torch",
+#     "kirin",
+#     "loguru",
+#     "numpy",
+#     "matplotlib",
+#     "pandas",
+#     "marimo>=0.17.0",
+#     "pyzmq",
+# ]
+#
+# [tool.uv.sources]
+# kirin = { path = "../", editable = true }
+# ///
+
+import marimo
+
+__generated_with = "0.17.8"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    """Setup imports and create model registry."""
+    import tempfile
+    from pathlib import Path
+    import torch
+    import torch.nn as nn
+    import numpy as np
+    import matplotlib.pyplot as plt
+    import pandas as pd
+    from loguru import logger
+
+    from kirin import Dataset
+
+    # Create a temporary directory for our model registry
+    temp_dir = tempfile.mkdtemp(prefix="kirin_model_demo_")
+    model_registry = Dataset(root_dir=temp_dir, name="sentiment_classifier")
+
+    print(f"Model registry created at: {temp_dir}")
+    print(f"Registry: {model_registry}")
+    return Path, model_registry, nn, pd, plt, temp_dir, torch
+
+
+@app.cell
+def _(nn):
+    """Create a simple PyTorch model for demonstration."""
+    class SimpleSentimentClassifier(nn.Module):
+        def __init__(self, vocab_size=1000, embedding_dim=128, hidden_dim=64):
+            super().__init__()
+            self.embedding = nn.Embedding(vocab_size, embedding_dim)
+            self.lstm = nn.LSTM(embedding_dim, hidden_dim, batch_first=True)
+            self.classifier = nn.Linear(hidden_dim, 2)  # binary classification
+            self.dropout = nn.Dropout(0.2)
+
+        def forward(self, x):
+            embedded = self.embedding(x)
+            lstm_out, _ = self.lstm(embedded)
+            # Use the last output
+            last_output = lstm_out[:, -1, :]
+            dropped = self.dropout(last_output)
+            return self.classifier(dropped)
+
+    # Create model instance
+    model = SimpleSentimentClassifier()
+
+    print("Created PyTorch model:")
+    print(f"  - Vocab size: 1000")
+    print(f"  - Embedding dim: 128")
+    print(f"  - Hidden dim: 64")
+    print(f"  - Parameters: {sum(p.numel() for p in model.parameters()):,}")
+    return SimpleSentimentClassifier, model
+
+
+@app.cell
+def _(Path, model, temp_dir, torch):
+    """Save initial model version with metadata."""
+    # Create model directory
+    model_dir = Path(temp_dir) / "models"
+    model_dir.mkdir(exist_ok=True)
+
+    # Save model weights
+    model_path = model_dir / "model_weights.pt"
+    torch.save(model.state_dict(), model_path)
+
+    # Create config file
+    config_path = model_dir / "config.json"
+    config_path.write_text('''{
+    "model_type": "SimpleSentimentClassifier",
+    "vocab_size": 1000,
+    "embedding_dim": 128,
+    "hidden_dim": 64,
+    "num_classes": 2
+    }''')
+
+    # Create training info
+    training_info_path = model_dir / "training_info.json"
+    training_info_path.write_text('''{
+    "dataset": "sentiment_analysis_v1",
+    "train_samples": 10000,
+    "val_samples": 2000,
+    "test_samples": 2000,
+    "batch_size": 32,
+    "learning_rate": 0.001,
+    "epochs": 10
+    }''')
+
+    print("Created model files:")
+    print(f"  - {model_path.name} ({model_path.stat().st_size} bytes)")
+    print(f"  - {config_path.name} ({config_path.stat().st_size} bytes)")
+    print(f"  - {training_info_path.name} ({training_info_path.stat().st_size} bytes)")
+    return config_path, model_path, training_info_path
+
+
+@app.cell
+def _(config_path, model_path, model_registry, training_info_path):
+    """Commit initial model version with comprehensive metadata."""
+    # Define metadata for the initial model
+    metadata = {
+        "framework": "pytorch",
+        "model_type": "SimpleSentimentClassifier",
+        "version": "1.0.0",
+        "accuracy": 0.87,
+        "f1_score": 0.85,
+        "precision": 0.88,
+        "recall": 0.82,
+        "hyperparameters": {
+            "vocab_size": 1000,
+            "embedding_dim": 128,
+            "hidden_dim": 64,
+            "learning_rate": 0.001,
+            "epochs": 10,
+            "batch_size": 32,
+        },
+        "training_data": {
+            "dataset": "sentiment_analysis_v1",
+            "train_samples": 10000,
+            "val_samples": 2000,
+            "test_samples": 2000,
+        },
+        "training_time_seconds": 1200,
+        "model_size_mb": 0.5,
+    }
+
+    tags = ["baseline", "v1.0"]
+
+    # Commit the initial model
+    commit_hash = model_registry.commit(
+        message="Initial baseline model - SimpleSentimentClassifier v1.0",
+        add_files=[str(model_path), str(config_path), str(training_info_path)],
+        metadata=metadata,
+        tags=tags,
+    )
+
+    print(f"✅ Committed initial model version")
+    print(f"   Commit hash: {commit_hash[:8]}")
+    print(f"   Tags: {tags}")
+    print(f"   Accuracy: {metadata['accuracy']}")
+    return
+
+
+@app.cell
+def _(Path, SimpleSentimentClassifier, temp_dir, torch):
+    """Simulate training an improved model version."""
+    # Simulate training by modifying the model slightly
+    # In real training, this would be done through actual training loops
+
+    # Create a "trained" version with slightly different weights
+    improved_model = SimpleSentimentClassifier()
+
+    # Simulate training by adding small random changes to weights
+    with torch.no_grad():
+        for improved_param in improved_model.parameters():
+            improved_param.add_(torch.randn_like(improved_param) * 0.01)
+
+    # Save improved model
+    improved_model_path = Path(temp_dir) / "models" / "model_weights_v2.pt"
+    torch.save(improved_model.state_dict(), improved_model_path)
+
+    # Create updated config
+    improved_config_path = Path(temp_dir) / "models" / "config_v2.json"
+    improved_config_path.write_text('''{
+    "model_type": "SimpleSentimentClassifier",
+    "vocab_size": 1000,
+    "embedding_dim": 128,
+    "hidden_dim": 64,
+    "num_classes": 2,
+    "improvements": ["better_regularization", "learning_rate_schedule"]
+    }''')
+
+    print("Created improved model files:")
+    print(f"  - {improved_model_path.name}")
+    print(f"  - {improved_config_path.name}")
+    return improved_config_path, improved_model_path
+
+
+@app.cell
+def _(improved_config_path, improved_model_path, model_registry):
+    """Commit improved model version with updated metadata."""
+    # Define metadata for the improved model
+    improved_metadata = {
+        "framework": "pytorch",
+        "model_type": "SimpleSentimentClassifier",
+        "version": "2.0.0",
+        "accuracy": 0.92,  # Improved accuracy
+        "f1_score": 0.90,  # Improved F1
+        "precision": 0.91,
+        "recall": 0.89,
+        "hyperparameters": {
+            "vocab_size": 1000,
+            "embedding_dim": 128,
+            "hidden_dim": 64,
+            "learning_rate": 0.0005,  # Lower learning rate
+            "epochs": 15,  # More epochs
+            "batch_size": 32,
+            "weight_decay": 0.01,  # Added regularization
+        },
+        "training_data": {
+            "dataset": "sentiment_analysis_v2",  # Updated dataset
+            "train_samples": 15000,  # More training data
+            "val_samples": 3000,
+            "test_samples": 3000,
+        },
+        "training_time_seconds": 1800,  # Longer training
+        "model_size_mb": 0.5,
+        "improvements": [
+            "Better regularization",
+            "Learning rate scheduling",
+            "More training data",
+            "Longer training time"
+        ],
+    }
+
+    improved_tags = ["improved", "v2.0", "production"]
+
+    # Commit the improved model
+    improved_commit_hash = model_registry.commit(
+        message="Improved model v2.0 - Better regularization and more data",
+        add_files=[str(improved_model_path), str(improved_config_path)],
+        metadata=improved_metadata,
+        tags=improved_tags,
+    )
+
+    print(f"✅ Committed improved model version")
+    print(f"   Commit hash: {improved_commit_hash[:8]}")
+    print(f"   Tags: {improved_tags}")
+    print(f"   Accuracy: {improved_metadata['accuracy']} (↑ from 0.87)")
+    return
+
+
+@app.cell
+def _(Path, SimpleSentimentClassifier, temp_dir, torch):
+    """Create a specialized model for a specific domain."""
+    # Create a domain-specific model (e.g., for medical sentiment)
+    domain_model = SimpleSentimentClassifier()
+
+    # Simulate domain-specific training
+    with torch.no_grad():
+        for domain_param in domain_model.parameters():
+            domain_param.add_(torch.randn_like(domain_param) * 0.02)  # Larger changes for domain adaptation
+
+    # Save domain-specific model
+    domain_model_path = Path(temp_dir) / "models" / "model_medical.pt"
+    torch.save(domain_model.state_dict(), domain_model_path)
+
+    # Create domain-specific config
+    domain_config_path = Path(temp_dir) / "models" / "config_medical.json"
+    domain_config_path.write_text('''{
+    "model_type": "SimpleSentimentClassifier",
+    "vocab_size": 1000,
+    "embedding_dim": 128,
+    "hidden_dim": 64,
+    "num_classes": 2,
+    "domain": "medical",
+    "specialization": "medical_sentiment_analysis"
+    }''')
+
+    print("Created domain-specific model files:")
+    print(f"  - {domain_model_path.name}")
+    print(f"  - {domain_config_path.name}")
+    return domain_config_path, domain_model_path
+
+
+@app.cell
+def _(domain_config_path, domain_model_path, model_registry):
+    """Commit domain-specific model with specialized metadata."""
+    # Define metadata for the domain-specific model
+    domain_metadata = {
+        "framework": "pytorch",
+        "model_type": "SimpleSentimentClassifier",
+        "version": "2.1.0",
+        "domain": "medical",
+        "accuracy": 0.89,  # Slightly lower on general data
+        "f1_score": 0.87,
+        "precision": 0.90,
+        "recall": 0.84,
+        "domain_accuracy": 0.94,  # Higher on medical data
+        "domain_f1": 0.92,
+        "hyperparameters": {
+            "vocab_size": 1000,
+            "embedding_dim": 128,
+            "hidden_dim": 64,
+            "learning_rate": 0.0003,
+            "epochs": 20,
+            "batch_size": 16,  # Smaller batch for domain adaptation
+            "domain_adaptation": True,
+        },
+        "training_data": {
+            "dataset": "medical_sentiment_v1",
+            "train_samples": 5000,  # Smaller medical dataset
+            "val_samples": 1000,
+            "test_samples": 1000,
+            "domain_specific": True,
+        },
+        "training_time_seconds": 2400,
+        "model_size_mb": 0.5,
+        "specialization": "Medical sentiment analysis",
+        "use_cases": ["patient_feedback", "medical_reviews", "clinical_notes"],
+    }
+
+    domain_tags = ["domain-specific", "medical", "v2.1", "specialized"]
+
+    # Commit the domain-specific model
+    domain_commit_hash = model_registry.commit(
+        message="Domain-specific model for medical sentiment analysis",
+        add_files=[str(domain_model_path), str(domain_config_path)],
+        metadata=domain_metadata,
+        tags=domain_tags,
+    )
+
+    print(f"✅ Committed domain-specific model")
+    print(f"   Commit hash: {domain_commit_hash[:8]}")
+    print(f"   Tags: {domain_tags}")
+    print(f"   General accuracy: {domain_metadata['accuracy']}")
+    print(f"   Medical accuracy: {domain_metadata['domain_accuracy']}")
+    return
+
+
+@app.cell
+def _(model_registry):
+    """Query and discover models using metadata and tags."""
+    print("🔍 Model Discovery and Querying")
+    print("=" * 50)
+
+    # Find all production models
+    production_models = model_registry.find_commits(tags=["production"])
+    print(f"\n📦 Production models: {len(production_models)}")
+    for prod_commit in production_models:
+        print(f"   {prod_commit.short_hash}: {prod_commit.message}")
+        print(f"      Tags: {prod_commit.tags}")
+        print(f"      Accuracy: {prod_commit.metadata.get('accuracy', 'N/A')}")
+
+    # Find high-accuracy models (>0.9)
+    high_accuracy_models = model_registry.find_commits(
+        metadata_filter=lambda m: m.get("accuracy", 0) > 0.9
+    )
+    print(f"\n🎯 High accuracy models (>0.9): {len(high_accuracy_models)}")
+    for high_acc_commit in high_accuracy_models:
+        print(f"   {high_acc_commit.short_hash}: {high_acc_commit.message}")
+        print(f"      Accuracy: {high_acc_commit.metadata.get('accuracy', 'N/A')}")
+
+    # Find domain-specific models
+    domain_models = model_registry.find_commits(
+        metadata_filter=lambda m: m.get("domain") is not None
+    )
+    print(f"\n🏥 Domain-specific models: {len(domain_models)}")
+    for domain_commit in domain_models:
+        print(f"   {domain_commit.short_hash}: {domain_commit.message}")
+        print(f"      Domain: {domain_commit.metadata.get('domain', 'N/A')}")
+        print(f"      Specialization: {domain_commit.metadata.get('specialization', 'N/A')}")
+
+    # Find models by version
+    v2_models = model_registry.find_commits(
+        metadata_filter=lambda m: m.get("version", "").startswith("2.")
+    )
+    print(f"\n🔢 Version 2.x models: {len(v2_models)}")
+    for v2_commit in v2_models:
+        print(f"   {v2_commit.short_hash}: {v2_commit.message}")
+        print(f"      Version: {v2_commit.metadata.get('version', 'N/A')}")
+    return high_accuracy_models, production_models
+
+
+@app.cell
+def _(model_registry, production_models):
+    """Compare different model versions."""
+    if len(production_models) >= 2:
+        print("🔄 Model Comparison")
+        print("=" * 30)
+
+        # Compare the two production models
+        commit1 = production_models[0]  # Most recent
+        commit2 = production_models[1]  # Previous
+
+        comparison = model_registry.compare_commits(commit1.hash, commit2.hash)
+
+        print(f"Comparing:")
+        print(f"  {comparison['commit1']['hash']}: {comparison['commit1']['message']}")
+        print(f"  {comparison['commit2']['hash']}: {comparison['commit2']['message']}")
+
+        print(f"\n📊 Metadata Changes:")
+        metadata_diff = comparison['metadata_diff']
+
+        if metadata_diff['added']:
+            print(f"  ➕ Added: {metadata_diff['added']}")
+        if metadata_diff['removed']:
+            print(f"  ➖ Removed: {metadata_diff['removed']}")
+        if metadata_diff['changed']:
+            print(f"  🔄 Changed:")
+            for changed_key, change in metadata_diff['changed'].items():
+                print(f"     {changed_key}: {change['old']} → {change['new']}")
+
+        print(f"\n🏷️  Tag Changes:")
+        tags_diff = comparison['tags_diff']
+        if tags_diff['added']:
+            print(f"  ➕ Added tags: {tags_diff['added']}")
+        if tags_diff['removed']:
+            print(f"  ➖ Removed tags: {tags_diff['removed']}")
+    else:
+        print("Not enough production models to compare")
+    return
+
+
+@app.cell
+def _(high_accuracy_models, model_registry, pd, plt):
+    """Visualize model performance metrics."""
+    if high_accuracy_models:
+        print("📈 Model Performance Visualization")
+        print("=" * 40)
+
+        # Extract metrics for visualization
+        commits = model_registry.history()
+        metrics_data = []
+
+        for metrics_commit in commits:
+            if metrics_commit.metadata:
+                metrics_data.append({
+                    'commit': metrics_commit.short_hash,
+                    'message': metrics_commit.message[:30] + "..." if len(metrics_commit.message) > 30 else metrics_commit.message,
+                    'accuracy': metrics_commit.metadata.get('accuracy', 0),
+                    'f1_score': metrics_commit.metadata.get('f1_score', 0),
+                    'version': metrics_commit.metadata.get('version', 'unknown'),
+                    'tags': ', '.join(metrics_commit.tags) if metrics_commit.tags else 'none',
+                })
+
+        if metrics_data:
+            # Create DataFrame for easier handling
+            df = pd.DataFrame(metrics_data)
+
+            print("\nModel Performance Summary:")
+            print(df[['commit', 'version', 'accuracy', 'f1_score', 'tags']].to_string(index=False))
+
+            # Create a simple visualization
+            fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+
+            # Accuracy over time
+            ax1.plot(range(len(df)), df['accuracy'], 'o-', linewidth=2, markersize=8)
+            ax1.set_title('Model Accuracy Over Time')
+            ax1.set_xlabel('Commit Order')
+            ax1.set_ylabel('Accuracy')
+            ax1.grid(True, alpha=0.3)
+            ax1.set_ylim(0.8, 1.0)
+
+            # F1 Score over time
+            ax2.plot(range(len(df)), df['f1_score'], 's-', color='orange', linewidth=2, markersize=8)
+            ax2.set_title('Model F1 Score Over Time')
+            ax2.set_xlabel('Commit Order')
+            ax2.set_ylabel('F1 Score')
+            ax2.grid(True, alpha=0.3)
+            ax2.set_ylim(0.8, 1.0)
+
+            plt.tight_layout()
+            plt.show()
+
+        # Return variables for reactive dependencies
+        ax1, ax2, commits, df, fig, metrics_data
+    else:
+        print("No high-accuracy models found for visualization")
+        # Return None values for reactive dependencies
+        ax1, ax2, commits, df, fig, metrics_data = None, None, None, None, None, None
+    return
+
+
+@app.cell
+def _(Path, model_registry):
+    """Demonstrate model loading and usage patterns."""
+    print("🚀 Model Loading and Usage Patterns")
+    print("=" * 40)
+
+    # Get the latest production model
+    prod_models_for_loading = model_registry.find_commits(tags=["production"])
+
+    if prod_models_for_loading:
+        latest_model = prod_models_for_loading[0]
+        print(f"Loading latest production model: {latest_model.short_hash}")
+
+        # Checkout the model
+        model_registry.checkout(latest_model.hash)
+
+        # Demonstrate lazy loading
+        print(f"\n📁 Files in this commit:")
+        for filename in model_registry.list_files():
+            file_obj = model_registry.get_file(filename)
+            print(f"   {filename}: {file_obj.size} bytes")
+
+        # Demonstrate lazy file access
+        print(f"\n💾 Lazy file loading (files only downloaded when accessed):")
+        with model_registry.local_files() as local_files:
+            print(f"   Available files: {list(local_files.keys())}")
+
+            # Files are only downloaded when accessed
+            for filename in local_files.keys():
+                local_path = local_files[filename]
+                print(f"   {filename} → {local_path}")
+                print(f"      File exists: {Path(local_path).exists()}")
+                print(f"      File size: {Path(local_path).stat().st_size} bytes")
+
+        print(f"\n📋 Model metadata:")
+        for metadata_key, value in latest_model.metadata.items():
+            if isinstance(value, dict):
+                print(f"   {metadata_key}:")
+                for sub_key, sub_value in value.items():
+                    print(f"     {sub_key}: {sub_value}")
+            else:
+                print(f"   {metadata_key}: {value}")
+
+        # Return variables for reactive dependencies
+        latest_model, local_files, local_path
+    else:
+        print("No production models found")
+        # Return None values for reactive dependencies
+        latest_model, local_files, local_path = None, None, None
+    return
+
+
+@app.cell
+def _(model_registry):
+    """Summary and key takeaways."""
+    print("🎯 Model Versioning with Kirin - Summary")
+    print("=" * 50)
+
+    # Get all commits
+    all_commits = model_registry.history()
+
+    print(f"\n📊 Registry Statistics:")
+    print(f"   Total commits: {len(all_commits)}")
+    print(f"   Total files: {sum(len(c.files) for c in all_commits)}")
+
+    # Count by tags
+    tag_counts = {}
+    for summary_commit in all_commits:
+        for tag in summary_commit.tags:
+            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+
+    print(f"\n🏷️  Tag Distribution:")
+    for tag, count in sorted(tag_counts.items()):
+        print(f"   {tag}: {count}")
+
+    # Count by framework
+    framework_counts = {}
+    for framework_commit in all_commits:
+        framework = framework_commit.metadata.get('framework', 'unknown')
+        framework_counts[framework] = framework_counts.get(framework, 0) + 1
+
+    print(f"\n🔧 Framework Distribution:")
+    for framework, count in sorted(framework_counts.items()):
+        print(f"   {framework}: {count}")
+
+    print(f"\n✨ Key Benefits Demonstrated:")
+    print(f"   ✅ Content-addressed storage (automatic deduplication)")
+    print(f"   ✅ Lazy loading (files only downloaded when needed)")
+    print(f"   ✅ Rich metadata tracking (hyperparameters, metrics, etc.)")
+    print(f"   ✅ Flexible tagging system (staging, versions, domains)")
+    print(f"   ✅ Powerful querying (by metadata, tags, or custom filters)")
+    print(f"   ✅ Model comparison and diffing")
+    print(f"   ✅ Linear history (simple, no branching complexity)")
+    print(f"   ✅ Cloud storage support (works with S3, GCS, Azure)")
+
+    print(f"\n🚀 Use Cases:")
+    print(f"   • Model experiment tracking")
+    print(f"   • A/B testing different model versions")
+    print(f"   • Model deployment staging (dev → staging → production)")
+    print(f"   • Domain-specific model specialization")
+    print(f"   • Model performance monitoring over time")
+    print(f"   • Reproducible ML workflows")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/notebooks/prototype.ipynb
+++ b/notebooks/prototype.ipynb
@@ -136,7 +136,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gitdata.catalog import Catalog\n",
+    "from kirin.catalog import Catalog\n",
     "\n",
     "c = Catalog(root_dir=here() / \"data\" / \"dummy\")\n",
     "c.datasets()\n",
@@ -186,7 +186,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "gitdata",
+   "display_name": "kirin",
    "language": "python",
    "name": "python3"
   },

--- a/scripts/analyze_commit_structure.py
+++ b/scripts/analyze_commit_structure.py
@@ -129,7 +129,7 @@ def main():
     if len(sys.argv) != 3:
         print("Usage: python analyze_commit_structure.py <dataset_path> <dataset_name>")
         print(
-            "Example: python analyze_commit_structure.py /tmp/gitdata-test-dataset test-dataset"
+            "Example: python analyze_commit_structure.py /tmp/kirin-test-dataset test-dataset"
         )
         sys.exit(1)
 

--- a/scripts/create_dummy_dataset.py
+++ b/scripts/create_dummy_dataset.py
@@ -12,7 +12,7 @@
 """
 Create a comprehensive dummy dataset demonstrating Kirin's full workflow.
 
-This script creates a dataset at /tmp/gitdata-test-dataset and demonstrates:
+This script creates a dataset at /tmp/kirin-test-dataset and demonstrates:
 1. Creating a dataset with main branch
 2. Writing two files over two commits
 3. Branching to 'add-third' from main and adding a third file
@@ -47,7 +47,7 @@ def main():
     """Create a comprehensive dummy dataset demonstrating Kirin's full workflow."""
 
     # Set up the dataset path
-    dataset_path = "/tmp/gitdata-test-dataset"
+    dataset_path = "/tmp/kirin-test-dataset"
 
     # Clean up any existing dataset
     if os.path.exists(dataset_path):
@@ -55,7 +55,7 @@ def main():
         shutil.rmtree(dataset_path)
 
     # Clean up any existing local state
-    local_state_dir = Path.home() / ".gitdata" / "test-dataset"
+    local_state_dir = Path.home() / ".kirin" / "test-dataset"
     if local_state_dir.exists():
         logger.info(f"Cleaning up existing local state at {local_state_dir}")
         shutil.rmtree(local_state_dir)

--- a/scripts/diagnose_commit_history.py
+++ b/scripts/diagnose_commit_history.py
@@ -169,7 +169,7 @@ def main():
     if len(sys.argv) != 3:
         print("Usage: python diagnose_commit_history.py <dataset_path> <dataset_name>")
         print(
-            "Example: python diagnose_commit_history.py /tmp/gitdata-test-dataset test-dataset"
+            "Example: python diagnose_commit_history.py /tmp/kirin-test-dataset test-dataset"
         )
         sys.exit(1)
 

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -1,1 +1,1 @@
-"""Tests for gitdata."""
+"""Tests for kirin."""

--- a/tests/test_async_auth_functions.py
+++ b/tests/test_async_auth_functions.py
@@ -2,12 +2,12 @@
 # requires-python = ">=3.13"
 # dependencies = [
 #     "pytest==8.3.4",
-#     "gitdata==0.0.1",
+#     "kirin==0.0.1",
 #     "loguru==0.7.3",
 # ]
 #
 # [tool.uv.sources]
-# gitdata = { path = "../", editable = true }
+# kirin = { path = "../", editable = true }
 # ///
 
 """Fast unit tests for async authentication timeout and auto-execution features."""

--- a/tests/test_commit_entity.py
+++ b/tests/test_commit_entity.py
@@ -94,6 +94,8 @@ def test_commit_to_dict():
         "timestamp": timestamp.isoformat(),
         "parent_hash": "def456",
         "files": {},
+        "metadata": {},
+        "tags": [],
     }
 
     assert data == expected
@@ -144,7 +146,7 @@ def test_commit_builder_initial():
     file = File(hash="hash1", name="file1.txt", size=100)
     builder.add_file("file1.txt", file)
 
-    commit = builder.build("Initial commit")
+    commit = builder("Initial commit")
 
     assert commit.is_initial
     assert commit.message == "Initial commit"
@@ -173,7 +175,7 @@ def test_commit_builder_with_parent():
     # Remove parent file
     builder.remove_file("parent.txt")
 
-    commit = builder.build("Child commit")
+    commit = builder("Child commit")
 
     assert not commit.is_initial
     assert commit.parent_hash == "parent123"
@@ -211,7 +213,7 @@ def test_commit_builder_custom_hash():
     builder.add_file("file1.txt", file)
 
     custom_hash = "custom123"
-    commit = builder.build("Test commit", custom_hash)
+    commit = builder("Test commit", custom_hash)
 
     assert commit.hash == custom_hash
 
@@ -228,7 +230,7 @@ def test_commit_builder_method_chaining():
         "file1.txt"
     )
 
-    commit = builder.build("Chained commit")
+    commit = builder("Chained commit")
 
     assert commit.get_file_count() == 1
     assert commit.has_file("file2.txt")

--- a/tests/test_commit_metadata.py
+++ b/tests/test_commit_metadata.py
@@ -1,0 +1,250 @@
+"""Tests for Commit entity with metadata and tags support."""
+
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from kirin.commit import Commit, CommitBuilder
+from kirin.file import File
+from kirin.storage import ContentStore
+
+
+class TestCommitMetadata:
+    """Test Commit entity with metadata and tags."""
+
+    def test_commit_creation_with_metadata_and_tags(self):
+        """Test creating a commit with metadata and tags."""
+        metadata = {
+            "framework": "pytorch",
+            "accuracy": 0.94,
+            "hyperparameters": {"lr": 0.001, "epochs": 10},
+        }
+        tags = ["production", "v2.0"]
+
+        commit = Commit(
+            hash="abc123",
+            message="Test commit",
+            timestamp=datetime.now(),
+            parent_hash=None,
+            files={},
+            metadata=metadata,
+            tags=tags,
+        )
+
+        assert commit.metadata == metadata
+        assert commit.tags == tags
+        assert commit.hash == "abc123"
+        assert commit.message == "Test commit"
+
+    def test_commit_creation_with_empty_metadata_and_tags(self):
+        """Test creating a commit with empty metadata and tags."""
+        commit = Commit(
+            hash="abc123",
+            message="Test commit",
+            timestamp=datetime.now(),
+            parent_hash=None,
+            files={},
+        )
+
+        assert commit.metadata == {}
+        assert commit.tags == []
+        assert commit.hash == "abc123"
+
+    def test_commit_serialization_with_metadata_and_tags(self):
+        """Test serializing and deserializing commits with metadata and tags."""
+        metadata = {
+            "framework": "pytorch",
+            "accuracy": 0.94,
+            "nested": {"key": "value"},
+        }
+        tags = ["production", "v2.0"]
+
+        original_commit = Commit(
+            hash="abc123",
+            message="Test commit",
+            timestamp=datetime.now(),
+            parent_hash=None,
+            files={},
+            metadata=metadata,
+            tags=tags,
+        )
+
+        # Test to_dict
+        commit_dict = original_commit.to_dict()
+        assert commit_dict["metadata"] == metadata
+        assert commit_dict["tags"] == tags
+        assert "hash" in commit_dict
+        assert "message" in commit_dict
+
+        # Test from_dict
+        restored_commit = Commit.from_dict(commit_dict)
+        assert restored_commit.metadata == metadata
+        assert restored_commit.tags == tags
+        assert restored_commit.hash == original_commit.hash
+        assert restored_commit.message == original_commit.message
+
+    def test_commit_backward_compatibility(self):
+        """Test that old commits without metadata/tags load correctly."""
+        # Simulate old commit data without metadata/tags
+        old_commit_data = {
+            "hash": "abc123",
+            "message": "Old commit",
+            "timestamp": datetime.now().isoformat(),
+            "parent_hash": None,
+            "files": {},
+        }
+
+        # Should load with empty defaults
+        commit = Commit.from_dict(old_commit_data)
+        assert commit.metadata == {}
+        assert commit.tags == []
+        assert commit.hash == "abc123"
+        assert commit.message == "Old commit"
+
+    def test_commit_immutability(self):
+        """Test that commit fields are immutable."""
+        metadata = {"key": "value"}
+        tags = ["tag1", "tag2"]
+
+        commit = Commit(
+            hash="abc123",
+            message="Test commit",
+            timestamp=datetime.now(),
+            parent_hash=None,
+            files={},
+            metadata=metadata,
+            tags=tags,
+        )
+
+        # Should not be able to modify commit fields
+        with pytest.raises(AttributeError):
+            commit.hash = "new_hash"
+
+        with pytest.raises(AttributeError):
+            commit.message = "new_message"
+
+        # Note: metadata and tags are dictionaries/lists, so their contents
+        # can be modified, but the commit itself is frozen
+        # This is expected behavior for frozen dataclasses
+
+
+class TestCommitBuilderMetadata:
+    """Test CommitBuilder with metadata and tags support."""
+
+    def test_commit_builder_with_metadata_and_tags(self):
+        """Test building commits with metadata and tags."""
+        metadata = {
+            "framework": "pytorch",
+            "accuracy": 0.94,
+        }
+        tags = ["production", "v2.0"]
+
+        builder = CommitBuilder()
+        builder.set_metadata(metadata)
+        builder.add_tags(tags)
+
+        commit = builder("Test commit")
+
+        assert commit.metadata == metadata
+        assert commit.tags == tags
+        assert commit.message == "Test commit"
+
+    def test_commit_builder_inherits_from_parent(self):
+        """Test that CommitBuilder inherits metadata/tags from parent commit."""
+        parent_metadata = {"parent_key": "parent_value"}
+        parent_tags = ["parent_tag"]
+
+        parent_commit = Commit(
+            hash="parent123",
+            message="Parent commit",
+            timestamp=datetime.now(),
+            parent_hash=None,
+            files={},
+            metadata=parent_metadata,
+            tags=parent_tags,
+        )
+
+        builder = CommitBuilder(parent_commit)
+        # Don't set new metadata/tags, should inherit from parent
+        commit = builder("Child commit")
+
+        # Should inherit from parent
+        assert commit.metadata == parent_metadata
+        assert commit.tags == parent_tags
+
+    def test_commit_builder_overrides_parent(self):
+        """Test that CommitBuilder can override parent metadata/tags."""
+        parent_metadata = {"parent_key": "parent_value"}
+        parent_tags = ["parent_tag"]
+
+        parent_commit = Commit(
+            hash="parent123",
+            message="Parent commit",
+            timestamp=datetime.now(),
+            parent_hash=None,
+            files={},
+            metadata=parent_metadata,
+            tags=parent_tags,
+        )
+
+        new_metadata = {"new_key": "new_value"}
+        new_tags = ["new_tag"]
+
+        builder = CommitBuilder(parent_commit)
+        builder.set_metadata(new_metadata)
+        builder.add_tags(new_tags)
+
+        commit = builder("Child commit")
+
+        # Should use new values, not parent values
+        assert commit.metadata == new_metadata
+        assert commit.tags == new_tags
+
+    def test_commit_builder_method_chaining(self):
+        """Test that CommitBuilder methods support chaining."""
+        metadata = {"key": "value"}
+        tags = ["tag1", "tag2"]
+
+        builder = CommitBuilder()
+        result = builder.set_metadata(metadata).add_tags(tags)
+
+        # Should return self for chaining
+        assert result is builder
+        assert builder.metadata == metadata
+        assert builder.tags == tags
+
+    def test_commit_builder_with_files_and_metadata(self):
+        """Test CommitBuilder with both files and metadata/tags."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a test file
+            test_file = Path(temp_dir) / "test.txt"
+            test_file.write_text("test content")
+
+            # Create storage
+            storage = ContentStore(temp_dir)
+
+            # Store file
+            content_hash = storage.store_content(b"test content", "test.txt")
+            file_obj = File(
+                hash=content_hash,
+                name="test.txt",
+                size=12,
+                _storage=storage,
+            )
+
+            metadata = {"framework": "pytorch"}
+            tags = ["test"]
+
+            builder = CommitBuilder()
+            builder.add_file("test.txt", file_obj)
+            builder.set_metadata(metadata)
+            builder.add_tags(tags)
+
+            commit = builder("Test commit with files and metadata")
+
+            assert commit.metadata == metadata
+            assert commit.tags == tags
+            assert "test.txt" in commit.files
+            assert commit.files["test.txt"] == file_obj

--- a/tests/test_dataset_metadata.py
+++ b/tests/test_dataset_metadata.py
@@ -1,0 +1,281 @@
+"""Integration tests for Dataset with metadata and tags support."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from kirin import Dataset
+
+
+class TestDatasetMetadata:
+    """Test Dataset functionality with metadata and tags."""
+
+    def test_commit_with_metadata_and_tags(self):
+        """Test committing with metadata and tags."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test files
+            test_file1 = Path(temp_dir) / "model.pt"
+            test_file1.write_text("model content")
+
+            test_file2 = Path(temp_dir) / "config.json"
+            test_file2.write_text('{"lr": 0.001}')
+
+            # Create dataset
+            dataset = Dataset(root_dir=temp_dir, name="test_model")
+
+            # Commit with metadata and tags
+            metadata = {
+                "framework": "pytorch",
+                "accuracy": 0.94,
+                "hyperparameters": {"lr": 0.001, "epochs": 10},
+            }
+            tags = ["production", "v2.0"]
+
+            commit_hash = dataset.commit(
+                message="Initial model commit",
+                add_files=[str(test_file1), str(test_file2)],
+                metadata=metadata,
+                tags=tags,
+            )
+
+            # Verify commit was created
+            assert commit_hash is not None
+            commit = dataset.get_commit(commit_hash)
+            assert commit is not None
+            assert commit.metadata == metadata
+            assert commit.tags == tags
+            assert commit.message == "Initial model commit"
+
+    def test_commit_without_metadata_and_tags(self):
+        """Test that commits work without metadata and tags (backward compatibility)."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test file
+            test_file = Path(temp_dir) / "test.txt"
+            test_file.write_text("test content")
+
+            # Create dataset
+            dataset = Dataset(root_dir=temp_dir, name="test_dataset")
+
+            # Commit without metadata/tags
+            commit_hash = dataset.commit(
+                message="Simple commit",
+                add_files=[str(test_file)],
+            )
+
+            # Verify commit was created with empty metadata/tags
+            commit = dataset.get_commit(commit_hash)
+            assert commit is not None
+            assert commit.metadata == {}
+            assert commit.tags == []
+            assert commit.message == "Simple commit"
+
+    def test_find_commits_by_tags(self):
+        """Test finding commits by tags."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test files
+            test_file = Path(temp_dir) / "test.txt"
+            test_file.write_text("test content")
+
+            dataset = Dataset(root_dir=temp_dir, name="test_model")
+
+            # Create multiple commits with different tags
+            dataset.commit(
+                message="Dev commit",
+                add_files=[str(test_file)],
+                tags=["dev"],
+            )
+
+            dataset.commit(
+                message="Staging commit",
+                add_files=[str(test_file)],
+                tags=["staging"],
+            )
+
+            dataset.commit(
+                message="Production commit",
+                add_files=[str(test_file)],
+                tags=["production"],
+            )
+
+            # Find commits by tags
+            dev_commits = dataset.find_commits(tags=["dev"])
+            assert len(dev_commits) == 1
+            assert dev_commits[0].tags == ["dev"]
+
+            staging_commits = dataset.find_commits(tags=["staging"])
+            assert len(staging_commits) == 1
+            assert staging_commits[0].tags == ["staging"]
+
+            production_commits = dataset.find_commits(tags=["production"])
+            assert len(production_commits) == 1
+            assert production_commits[0].tags == ["production"]
+
+            # Find commits with multiple tags
+            multi_tag_commits = dataset.find_commits(tags=["dev", "staging"])
+            assert len(multi_tag_commits) == 0  # No commit has both tags
+
+    def test_find_commits_by_metadata_filter(self):
+        """Test finding commits by metadata filter."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test file
+            test_file = Path(temp_dir) / "test.txt"
+            test_file.write_text("test content")
+
+            dataset = Dataset(root_dir=temp_dir, name="test_model")
+
+            # Create commits with different metadata
+            dataset.commit(
+                message="Low accuracy model",
+                add_files=[str(test_file)],
+                metadata={"accuracy": 0.85, "framework": "pytorch"},
+            )
+
+            dataset.commit(
+                message="High accuracy model",
+                add_files=[str(test_file)],
+                metadata={"accuracy": 0.95, "framework": "pytorch"},
+            )
+
+            dataset.commit(
+                message="TensorFlow model",
+                add_files=[str(test_file)],
+                metadata={"accuracy": 0.91, "framework": "tensorflow"},
+            )
+
+            # Find high accuracy models
+            high_accuracy = dataset.find_commits(
+                metadata_filter=lambda m: m.get("accuracy", 0) > 0.9
+            )
+            assert len(high_accuracy) == 2
+            assert all(c.metadata["accuracy"] > 0.9 for c in high_accuracy)
+
+            # Find PyTorch models
+            pytorch_models = dataset.find_commits(
+                metadata_filter=lambda m: m.get("framework") == "pytorch"
+            )
+            assert len(pytorch_models) == 2
+            assert all(c.metadata["framework"] == "pytorch" for c in pytorch_models)
+
+            # Find high accuracy PyTorch models
+            high_pytorch = dataset.find_commits(
+                metadata_filter=lambda m: (
+                    m.get("accuracy", 0) > 0.9 and m.get("framework") == "pytorch"
+                )
+            )
+            assert len(high_pytorch) == 1
+            assert high_pytorch[0].metadata["accuracy"] == 0.95
+
+    def test_find_commits_with_limit(self):
+        """Test finding commits with limit."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test file
+            test_file = Path(temp_dir) / "test.txt"
+            test_file.write_text("test content")
+
+            dataset = Dataset(root_dir=temp_dir, name="test_model")
+
+            # Create multiple commits
+            for i in range(5):
+                dataset.commit(
+                    message=f"Commit {i}",
+                    add_files=[str(test_file)],
+                    metadata={"index": i},
+                )
+
+            # Find with limit
+            limited_commits = dataset.find_commits(limit=3)
+            assert len(limited_commits) == 3
+
+            # Should be newest first
+            assert limited_commits[0].metadata["index"] == 4
+            assert limited_commits[1].metadata["index"] == 3
+            assert limited_commits[2].metadata["index"] == 2
+
+    def test_compare_commits(self):
+        """Test comparing commits."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test file
+            test_file = Path(temp_dir) / "test.txt"
+            test_file.write_text("test content")
+
+            dataset = Dataset(root_dir=temp_dir, name="test_model")
+
+            # Create first commit
+            commit1_hash = dataset.commit(
+                message="First commit",
+                add_files=[str(test_file)],
+                metadata={"accuracy": 0.85, "framework": "pytorch"},
+                tags=["dev"],
+            )
+
+            # Create second commit
+            commit2_hash = dataset.commit(
+                message="Second commit",
+                add_files=[str(test_file)],
+                metadata={"accuracy": 0.95, "framework": "pytorch", "epochs": 100},
+                tags=["production"],
+            )
+
+            # Compare commits
+            comparison = dataset.compare_commits(commit1_hash, commit2_hash)
+
+            # Check basic info
+            commit1 = dataset.get_commit(commit1_hash)
+            commit2 = dataset.get_commit(commit2_hash)
+            assert comparison["commit1"]["hash"] == commit1.short_hash
+            assert comparison["commit2"]["hash"] == commit2.short_hash
+
+            # Check metadata diff
+            assert comparison["metadata_diff"]["added"] == {"epochs": 100}
+            assert comparison["metadata_diff"]["changed"]["accuracy"] == {
+                "old": 0.85,
+                "new": 0.95,
+            }
+
+            # Check tags diff
+            assert comparison["tags_diff"]["added"] == ["production"]
+            assert comparison["tags_diff"]["removed"] == ["dev"]
+
+    def test_compare_commits_not_found(self):
+        """Test comparing commits when one doesn't exist."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dataset = Dataset(root_dir=temp_dir, name="test_model")
+
+            # Try to compare non-existent commits
+            with pytest.raises(ValueError, match="One or both commits not found"):
+                dataset.compare_commits("nonexistent1", "nonexistent2")
+
+    def test_round_trip_serialization(self):
+        """Test that metadata and tags survive round-trip serialization."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create test file
+            test_file = Path(temp_dir) / "test.txt"
+            test_file.write_text("test content")
+
+            dataset = Dataset(root_dir=temp_dir, name="test_model")
+
+            # Create commit with metadata and tags
+            metadata = {
+                "framework": "pytorch",
+                "accuracy": 0.94,
+                "nested": {"key": "value"},
+            }
+            tags = ["production", "v2.0"]
+
+            commit_hash = dataset.commit(
+                message="Test commit",
+                add_files=[str(test_file)],
+                metadata=metadata,
+                tags=tags,
+            )
+
+            # Create new dataset instance (simulates loading from storage)
+            new_dataset = Dataset(root_dir=temp_dir, name="test_model")
+
+            # Verify metadata and tags are preserved
+            commit = new_dataset.get_commit(commit_hash)
+            assert commit is not None
+            assert commit.metadata == metadata
+            assert commit.tags == tags
+            assert commit.message == "Test commit"

--- a/tests/test_file_access.py
+++ b/tests/test_file_access.py
@@ -1,4 +1,4 @@
-"""Tests for file access methods in GitData."""
+"""Tests for file access methods in Kirin."""
 
 import os
 from pathlib import Path

--- a/tests/test_gcs_integration.py
+++ b/tests/test_gcs_integration.py
@@ -17,7 +17,7 @@ try:
     fs = gcsfs.GCSFileSystem()
     # Try to access the test bucket
     try:
-        fs.ls("gitdata-test-bucket")
+        fs.ls("kirin-test-bucket")
         GCS_AVAILABLE = True
     except Exception:
         pass
@@ -33,9 +33,9 @@ pytestmark = pytest.mark.skipif(
 
 def test_gcs_dataset_creation():
     """Test creating a dataset on GCS."""
-    ds = Dataset(root_dir="gs://gitdata-test-bucket", name="test")
+    ds = Dataset(root_dir="gs://kirin-test-bucket", name="test")
     assert ds.name == "test"
-    assert "gs://gitdata-test-bucket" in ds.root_dir
+    assert "gs://kirin-test-bucket" in ds.root_dir
 
 
 def test_gcs_dataset_commit():
@@ -47,7 +47,7 @@ def test_gcs_dataset_commit():
 
     try:
         # Create dataset
-        ds = Dataset(root_dir="gs://gitdata-test-bucket", name="test-commit")
+        ds = Dataset(root_dir="gs://kirin-test-bucket", name="test-commit")
 
         # Commit the file
         ds.commit(commit_message="Test commit to GCS", add_files=[temp_file])
@@ -75,7 +75,7 @@ def test_gcs_dataset_checkout():
         temp_file2 = f.name
 
     try:
-        ds = Dataset(root_dir="gs://gitdata-test-bucket", name="test-checkout")
+        ds = Dataset(root_dir="gs://kirin-test-bucket", name="test-checkout")
 
         # First commit
         ds.commit(commit_message="First commit", add_files=[temp_file1])
@@ -106,7 +106,7 @@ def test_gcs_dataset_checkout():
 def test_gcs_dataset_metadata():
     """Test reading metadata from GCS dataset."""
     ds = Dataset(
-        root_dir="gs://gitdata-test-bucket",
+        root_dir="gs://kirin-test-bucket",
         name="test-metadata",
         description="Test dataset for metadata",
     )
@@ -122,7 +122,7 @@ def test_gcs_dataset_metadata():
 def test_gcs_dataset_reopen(name):
     """Test that we can reopen existing GCS datasets."""
     # This should not raise an error even if the dataset exists
-    ds = Dataset(root_dir="gs://gitdata-test-bucket", name=name)
+    ds = Dataset(root_dir="gs://kirin-test-bucket", name=name)
     assert ds.name == name
     # Should be able to get metadata
     metadata = ds.metadata()

--- a/tests/test_integration_workflow.py
+++ b/tests/test_integration_workflow.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Integration test for complete GitData workflow:
+Integration test for complete Kirin workflow:
 1. Create a new dataset on local filesystem
 2. Commit 3 text files
 3. Create a new branch
@@ -27,7 +27,7 @@ def create_test_files(directory: Path, files: list) -> None:
 
 
 def test_complete_kirin_linear_workflow():
-    """Test the complete GitData workflow with proper assertions."""
+    """Test the complete Kirin workflow with proper assertions."""
 
     # Setup test environment
     test_dir = Path("test-integration-workflow")


### PR DESCRIPTION
- Extend Commit and CommitBuilder to support metadata and tags fields for model versioning.
- Update Dataset.commit() to accept metadata and tags parameters and propagate them to commits.
- Implement Dataset.find_commits() and compare_commits() for querying and comparing model versions by metadata and tags.
- Update documentation and API reference to describe new model versioning features and usage patterns.
- Add comprehensive tests for commit and dataset metadata/tags, including serialization, querying, and diffing.
- Add a new guide and demo notebook for model versioning workflows.
- Rename all references from gitdata to kirin throughout the codebase, docs, and tests.