### PR TITLE
feat(widgets): raster image preview in notebook widgets

### DIFF
--- a/kirin/commit.py
+++ b/kirin/commit.py
@@ -167,7 +167,11 @@ class Commit:
         Returns:
             Dictionary with commit data for widget rendering
         """
-        from .html_repr import format_file_size, get_file_icon_html
+        from .html_repr import (
+            format_file_size,
+            get_file_icon_html,
+            widget_raster_image_data_uri,
+        )
 
         file_count = len(self.files)
         total_size = sum(f.size for f in self.files.values())
@@ -210,10 +214,11 @@ class Commit:
                     file_data["content"] = None
                     file_data["is_text"] = False
             elif is_image:
-                # For images, we'll need to get the data URL or path
-                # For now, mark it as an image
                 file_data["is_image"] = True
                 file_data["is_text"] = False
+                image_uri = widget_raster_image_data_uri(file_obj)
+                if image_uri:
+                    file_data["image_data_uri"] = image_uri
             else:
                 file_data["is_text"] = False
                 file_data["is_image"] = False

--- a/kirin/dataset.py
+++ b/kirin/dataset.py
@@ -863,7 +863,11 @@ class Dataset:
         Returns:
             Dictionary with dataset data for widget rendering
         """
-        from .html_repr import format_file_size, get_file_icon_html
+        from .html_repr import (
+            format_file_size,
+            get_file_icon_html,
+            widget_raster_image_data_uri,
+        )
 
         commit_count = self.commit_store.get_commit_count()
         total_size = None
@@ -920,10 +924,11 @@ class Dataset:
                         file_data["content"] = None
                         file_data["is_text"] = False
                 elif is_image:
-                    # For images, we'll need to get the data URL or path
-                    # For now, mark it as an image
                     file_data["is_image"] = True
                     file_data["is_text"] = False
+                    image_uri = widget_raster_image_data_uri(file_obj)
+                    if image_uri:
+                        file_data["image_data_uri"] = image_uri
                 else:
                     file_data["is_text"] = False
                     file_data["is_image"] = False

--- a/kirin/html_repr.py
+++ b/kirin/html_repr.py
@@ -1,8 +1,17 @@
 """HTML representation utilities for Dataset, Commit, and Catalog classes."""
 
+import base64
 import html
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from kirin.file import File
+
+# Max size for embedding raster images as data URLs in notebook widget HTML.
+WIDGET_RASTER_IMAGE_MAX_PREVIEW_BYTES = 2 * 1024 * 1024
 
 
 def escape_html(text: str) -> str:
@@ -86,6 +95,90 @@ def get_file_icon_html(filename: str, content_type: Optional[str] = None) -> str
     }
 
     return icons.get(file_type, icons["file"])
+
+
+def is_raster_image_file(filename: str, content_type: Optional[str]) -> bool:
+    """True if the file is PNG, JPEG, GIF, or WebP (not SVG) for widget preview."""
+
+    lower = filename.lower()
+    if lower.endswith(".svg"):
+        return False
+    trimmed_type = ""
+    if content_type:
+        trimmed_type = content_type.split(";")[0].strip().lower()
+        if trimmed_type == "image/svg+xml":
+            return False
+
+    raster_extensions = (".png", ".jpg", ".jpeg", ".gif", ".webp")
+    if any(lower.endswith(ext) for ext in raster_extensions):
+        return True
+
+    if trimmed_type in (
+        "image/png",
+        "image/jpeg",
+        "image/jpg",
+        "image/gif",
+        "image/webp",
+        "image/pjpeg",
+    ):
+        return True
+
+    return False
+
+
+def raster_mime_for_widget_data_uri(
+    filename: str, content_type: Optional[str]
+) -> Optional[str]:
+    """Infer image/* MIME for raster widget previews from filename and metadata."""
+
+    trimmed = ""
+    if content_type:
+        trimmed = content_type.split(";")[0].strip().lower()
+    if trimmed == "image/jpg":
+        trimmed = "image/jpeg"
+    raster_mimes = {
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "image/pjpeg",
+    }
+    if trimmed in raster_mimes:
+        if trimmed == "image/pjpeg":
+            return "image/jpeg"
+        return trimmed
+
+    ext = Path(filename).suffix.lower()
+    return {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+    }.get(ext)
+
+
+def widget_raster_image_data_uri(
+    file_obj: "File",
+    max_bytes: int = WIDGET_RASTER_IMAGE_MAX_PREVIEW_BYTES,
+) -> Optional[str]:
+    """Build a raster data-URI (``data:image/...;base64,...``) if within size cap."""
+
+    filename = file_obj.name
+    if not is_raster_image_file(filename, file_obj.content_type):
+        return None
+    mime = raster_mime_for_widget_data_uri(filename, file_obj.content_type)
+    if mime is None:
+        return None
+    if file_obj.size > max_bytes:
+        return None
+    try:
+        raw = file_obj.read_bytes()
+    except OSError as e:
+        logger.debug(f"Skipped raster preview for {filename}: {e}")
+        return None
+    b64 = base64.b64encode(raw).decode("ascii")
+    return f"data:{mime};base64,{b64}"
 
 
 def get_inline_css() -> str:

--- a/kirin/widgets/assets/shared.css
+++ b/kirin/widgets/assets/shared.css
@@ -528,3 +528,16 @@ body {
   white-space: pre;
   word-wrap: normal;
 }
+
+/* Raster image preview (notebook widget static HTML) */
+.widget-raster-image-wrap {
+  max-width: 100%;
+  text-align: center;
+}
+
+.file-preview .widget-raster-image {
+  max-width: 100%;
+  height: auto;
+  border-radius: calc(var(--radius) - 2px);
+  border: 1px solid hsl(var(--border));
+}

--- a/kirin/widgets/templates/macros.html
+++ b/kirin/widgets/templates/macros.html
@@ -53,7 +53,18 @@
                 <h4 class="panel-title">Preview: {{ file_info.name }}</h4>
             </div>
             <div class="panel-content">
-                <p class="text-muted-foreground">Image preview not yet implemented</p>
+                {% if file_info.image_data_uri %}
+                <div class="widget-raster-image-wrap">
+                    <img src="{{ file_info.image_data_uri }}"
+                         alt="{{ file_info.name|e }}"
+                         class="widget-raster-image"
+                         loading="lazy">
+                </div>
+                {% else %}
+                <p class="text-muted-foreground">
+                    Raster preview unavailable (too large) or unsupported here (e.g.&nbsp;SVG). Use Copy Code / local_files() to view the file.
+                </p>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/tests/test_widget_raster_preview.py
+++ b/tests/test_widget_raster_preview.py
@@ -1,0 +1,144 @@
+"""Tests for raster image previews in notebook widgets."""
+
+from pathlib import Path
+
+from PIL import Image
+
+from kirin.html_repr import (
+    WIDGET_RASTER_IMAGE_MAX_PREVIEW_BYTES,
+    is_raster_image_file,
+    raster_mime_for_widget_data_uri,
+    widget_raster_image_data_uri,
+)
+
+
+def test_is_raster_image_file_recognizes_extensions():
+    """Raster helper accepts common raster types and rejects SVG."""
+
+    assert is_raster_image_file("a.png", "application/octet-stream") is True
+    assert is_raster_image_file("a.PNG", None) is True
+    assert is_raster_image_file("photo.jpg", "image/jpeg") is True
+    assert is_raster_image_file("x.webp", None) is True
+
+    assert is_raster_image_file("plot.svg", "image/svg+xml") is False
+    assert is_raster_image_file("plot.svg", None) is False
+
+
+def test_raster_mime_for_widget_data_uri():
+    """MIME inference aligns with filename and content-type."""
+
+    assert raster_mime_for_widget_data_uri("x.png", "image/png") == "image/png"
+    assert raster_mime_for_widget_data_uri("x.jpg", None) == "image/jpeg"
+
+
+def test_widget_raster_image_data_uri_small_png(temp_dir):
+    """Committed PNG produces a PNG data URI for widgets."""
+
+    from kirin import Dataset
+
+    path = Path(temp_dir) / "plot.png"
+    Image.new("RGB", (12, 8), color="blue").save(path)
+
+    ds = Dataset(root_dir=temp_dir, name="ds_raster")
+    ds.commit(message="add png", add_files=[str(path)])
+
+    data = ds._get_widget_data()
+    file_entry = next(f for f in data["files"] if f["name"] == "plot.png")
+
+    assert file_entry["is_image"] is True
+    uri = file_entry["image_data_uri"]
+    assert uri is not None
+    assert uri.startswith("data:image/png;base64,")
+
+
+def test_widget_raster_commit_has_data_uri(temp_dir):
+    """Commit widget data includes raster data URI."""
+
+    from kirin import Dataset
+
+    path = Path(temp_dir) / "snap.gif"
+    Image.new("RGB", (4, 4), color=(200, 10, 20)).save(path, format="GIF")
+
+    ds = Dataset(root_dir=temp_dir, name="ds_gif")
+    commit_hash = ds.commit(message="gif", add_files=[str(path)])
+    commit = ds.get_commit(commit_hash)
+
+    data = commit._get_widget_data()
+    file_entry = next(f for f in data["files"] if f["name"] == "snap.gif")
+
+    assert file_entry["is_image"] is True
+    assert file_entry["image_data_uri"].startswith("data:image/gif;base64,")
+
+
+def test_svg_remains_preview_marker_without_uri(temp_dir):
+    """SVG commits stay is_image without embedded raster URI."""
+
+    from kirin import Dataset
+
+    svg = Path(temp_dir) / "vector.svg"
+    svg.write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg">'
+        '<rect width="1" height="1"/></svg>'
+    )
+
+    ds = Dataset(root_dir=temp_dir, name="ds_svg")
+    ds.commit(message="svg", add_files=[str(svg)])
+
+    data = ds._get_widget_data()
+    file_entry = next(f for f in data["files"] if f["name"] == "vector.svg")
+
+    assert file_entry["is_image"] is True
+    assert file_entry.get("image_data_uri") is None
+
+
+def test_widget_static_html_contains_img_for_raster(temp_dir):
+    """Static HTML renders an img tag when image_data_uri is set."""
+
+    from kirin.widgets import DatasetWidget
+
+    data_with_image = {
+        "name": "x",
+        "description": "",
+        "commit_count": 1,
+        "total_size": "1 B",
+        "current_commit": {"hash": "a", "message": "m"},
+        "files": [
+            {
+                "name": "a.png",
+                "size": "100 B",
+                "icon_html": "<svg>x</svg>",
+                "content_type": "image/png",
+                "is_image": True,
+                "is_text": False,
+                "image_data_uri": "data:image/png;base64,abab",
+            }
+        ],
+        "history": [],
+        "has_commit": True,
+    }
+
+    html = DatasetWidget(data=data_with_image)._generate_static_html(data_with_image)
+
+    assert 'class="widget-raster-image"' in html
+    assert "data:image/png;base64,abab" in html
+
+
+def test_widget_raster_image_data_uri_rejects_oversized_file(temp_dir):
+    """Embedded preview returns None when file bytes exceed caller max."""
+
+    from kirin import Dataset
+
+    path = Path(temp_dir) / "tiny.png"
+    Image.new("RGB", (20, 20), color="green").save(path)
+
+    ds = Dataset(root_dir=temp_dir, name="ds_cap")
+    ds.commit(message="png", add_files=[str(path)])
+    png_file = ds.get_file("tiny.png")
+
+    assert png_file.size > 20
+    assert widget_raster_image_data_uri(png_file, max_bytes=10) is None
+    uri = widget_raster_image_data_uri(
+        png_file,
+        max_bytes=WIDGET_RASTER_IMAGE_MAX_PREVIEW_BYTES,
+    )
+    assert uri is not None and uri.startswith("data:image/png;base64,")


### PR DESCRIPTION
## Summary

Notebook/widget file previews (/commit repr HTML) now embed **PNG, JPEG, GIF, and WebP** as `data:image/...;base64,...` URIs when the blob is within **2 MiB**.

**SVG** still has no inline preview (unchanged intent); users see a short fallback message pointing at `local_files()`.

## Implementation

- `kirin/html_repr.py`: `is_raster_image_file`, `raster_mime_for_widget_data_uri`, `widget_raster_image_data_uri`, `WIDGET_RASTER_IMAGE_MAX_PREVIEW_BYTES`.
- `Dataset._get_widget_data()` / `Commit._get_widget_data()`: set `image_data_uri` for qualifying rasters.
- `kirin/widgets/templates/macros.html`: render `<img class="widget-raster-image">` when `image_data_uri` is present.
- `shared.css`: constrain image width in `.file-preview`.

## Tests

`tests/test_widget_raster_preview.py`: helpers, dataset/commit commits, SVG no-URI, HTML contains `img`, size cap.

`pixi run -e tests pytest tests/web_ui/ tests/test_widgets.py tests/test_widget_raster_preview.py` — 74 passed.

Made with [Cursor](https://cursor.com)